### PR TITLE
Edits and additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Okta Identity Defense Operations is a team of security practitioners that help O
 | `hunts/`  | Threat hunting queries useful for aiding in detection use case creation  |
 | `logs/`  | CSV file with descriptions and examples of log fields within the Okta system log  |
 | `workflows/`  | Okta Workflows templates for security incident response and proactive threat mitigation  |
+| `sample_osquery_checks/` | Okta osquery check templates for using in Okta's Advanced Posture Checks                                                     |
 
 ## Getting Started
 The System Log provides a detailed log of user, admin and support events relevant to use of the Okta Workforce Identity Cloud.

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Welcome to the Okta Security Detection Catalog. This repository contains a colle
 Okta Identity Defense Operations is a team of security practitioners that help Okta customers investigate and respond to security incidents. If you are an Okta customer and need support with a security breach or incident, open a support case and indicate that you are investigating a security incident.
 
 ## File Structure
-| Folder | Description |
-| ------------- | ------------- |
-| `detections/`  | List of YAML files for recommended security detections Okta customers can implement within their security monitoring system.   |
-| `hunts/`  | Threat hunting queries useful for aiding in detection use case creation  |
-| `logs/`  | CSV file with descriptions and examples of log fields within the Okta system log  |
-| `workflows/`  | Okta Workflows templates for security incident response and proactive threat mitigation  |
+| Folder                   | Description                                                                                                                  |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `detections/`            | List of YAML files for recommended security detections Okta customers can implement within their security monitoring system. |
+| `hunts/`                 | Threat hunting queries useful for aiding in detection use case creation                                                      |
+| `logs/`                  | CSV file with descriptions and examples of log fields within the Okta system log                                             |
+| `workflows/`             | Okta Workflows templates for security incident response and proactive threat mitigation                                      |
 | `sample_osquery_checks/` | Okta osquery check templates for using in Okta's Advanced Posture Checks                                                     |
 
 ## Getting Started
@@ -31,13 +31,13 @@ Most events in System Log follow a similar pattern:\
 
 Some of the queries listed below use the following operators to group multiple events together:
 
-| Operator | Description |
-| ------------- | ------------- |
-| `eq` | Equals |
-| `ne` | Not Equal to | 
-| `sw` | Starts With |
-| `ew` | Ends With | 
-| `co` | Contains |
+| Operator | Description  |
+| -------- | ------------ |
+| `eq`     | Equals       |
+| `ne`     | Not Equal to |
+| `sw`     | Starts With  |
+| `ew`     | Ends With    |
+| `co`     | Contains     |
 
 Okta recommends customers review these detections and run searches using those that appear to be applicable to your environment. Perform any necessary tuning or baselining to ensure they deliver high fidelity results prior to creating an alert. 
 

--- a/sample_osquery_checks/Cross/bufferzonecorp_campaign_detection.yml
+++ b/sample_osquery_checks/Cross/bufferzonecorp_campaign_detection.yml
@@ -1,26 +1,34 @@
 title: BufferZoneCorp Supply Chain Campaign Detection
 id: 13b477e7468e42baa9e82733bed55723
 description: |
-  Detects artifacts from the BufferZoneCorp supply chain attack campaign, which distributes malicious
-  Ruby gems and Go modules designed to steal developer credentials and establish persistent backdoor
-  access. The campaign is orchestrated via the BufferZoneCorp GitHub account and uses two distinct
-  attack vectors. The Ruby vector publishes seven gems under the 'knot-theory' publisher identity
+  Detects artifacts from the BufferZoneCorp supply chain attack campaign, which distributes
+  malicious Ruby gems and Go modules designed to steal developer credentials and establish
+  persistent backdoor access. The campaign is orchestrated via the BufferZoneCorp GitHub
+  account and uses two distinct attack vectors.
+
+  The Ruby vector publishes seven gems under the 'knot-theory' publisher identity
   (knot-activesupport-logger, knot-devise-jwt-helper, knot-rack-session-store,
-  knot-rails-assets-pipeline, knot-rspec-formatter-json, and sleepers knot-date-utils-rb and
-  knot-simple-formatter) that execute a credential-harvesting payload at install time via extconf.rb,
-  stealing SSH keys, AWS credentials, npm tokens, GitHub CLI config, and RubyGems tokens, with all
-  data exfiltrated to webhook[.]site/49c21843-c27c-4a1b-b1f6-037c3998055f. The Go vector distributes
-  nine modules (go-metrics-sdk, go-weather-sdk, go-retryablehttp, go-stdlib-ext, grpc-client,
-  net-helper, config-loader, and sleepers log-core and go-envconfig) that poison CI/CD pipelines by
-  disabling Go module verification (GOSUMDB), manipulating GOPROXY, and injecting fake 'go' wrappers
-  into PATH. The most severe Go module (go-stdlib-ext) also establishes persistent SSH backdoor access
-  by appending a hardcoded attacker-controlled ed25519 key (deploy@buildserver) to the victim's
-  authorized_keys file. Detection aggregates two signals — presence of knot-* gem directories in
-  common Ruby installation paths, and the specific attacker SSH public key in authorized_keys — into
-  a score. A score greater than 0 (any single positive indicator) triggers detection, as both signals
-  are specific enough to warrant immediate investigation. A positive result requires removal of
-  affected packages, rotation of all credentials on the system, removal of the backdoor SSH key, and
-  audit of CI/CD pipeline configurations and go.sum files.
+  knot-rails-assets-pipeline, knot-rspec-formatter-json, knot-date-utils-rb, and
+  knot-simple-formatter). These gems execute a credential-harvesting payload at install time
+  via extconf.rb, stealing SSH keys, AWS credentials, npm tokens, GitHub CLI config, and
+  RubyGems tokens. All data is exfiltrated to
+  webhook[.]site/49c21843-c27c-4a1b-b1f6-037c3998055f.
+
+  The Go vector distributes nine modules (go-metrics-sdk, go-weather-sdk, go-retryablehttp,
+  go-stdlib-ext, grpc-client, net-helper, config-loader, log-core, and go-envconfig) that
+  poison CI/CD pipelines by disabling Go module verification (GOSUMDB), manipulating GOPROXY,
+  and injecting fake 'go' wrappers into PATH. The most severe module (go-stdlib-ext) also
+  establishes persistent SSH backdoor access by appending a hardcoded attacker-controlled
+  ed25519 key (deploy@buildserver) to the victim's authorized_keys file.
+
+  Detection aggregates two signals — presence of knot-* gem directories in common Ruby
+  installation paths, and the specific attacker SSH public key in authorized_keys — into a
+  score. A score greater than 0 (any single positive indicator) triggers detection, as both
+  signals are specific enough to warrant immediate investigation.
+
+  A positive result requires removal of affected packages, rotation of all credentials on the
+  system, removal of the backdoor SSH key, and audit of CI/CD pipeline configurations and
+  go.sum files.
 references:
   - https://socket.dev/blog/malicious-ruby-gems-and-go-modules-steal-secrets-poison-ci
 author:

--- a/sample_osquery_checks/Cross/bufferzonecorp_campaign_detection.yml
+++ b/sample_osquery_checks/Cross/bufferzonecorp_campaign_detection.yml
@@ -1,0 +1,57 @@
+title: BufferZoneCorp Supply Chain Campaign Detection
+id: 13b477e7468e42baa9e82733bed55723
+description: |
+  Detects artifacts from the BufferZoneCorp supply chain attack campaign, which distributes malicious
+  Ruby gems and Go modules designed to steal developer credentials and establish persistent backdoor
+  access. The campaign is orchestrated via the BufferZoneCorp GitHub account and uses two distinct
+  attack vectors. The Ruby vector publishes seven gems under the 'knot-theory' publisher identity
+  (knot-activesupport-logger, knot-devise-jwt-helper, knot-rack-session-store,
+  knot-rails-assets-pipeline, knot-rspec-formatter-json, and sleepers knot-date-utils-rb and
+  knot-simple-formatter) that execute a credential-harvesting payload at install time via extconf.rb,
+  stealing SSH keys, AWS credentials, npm tokens, GitHub CLI config, and RubyGems tokens, with all
+  data exfiltrated to webhook[.]site/49c21843-c27c-4a1b-b1f6-037c3998055f. The Go vector distributes
+  nine modules (go-metrics-sdk, go-weather-sdk, go-retryablehttp, go-stdlib-ext, grpc-client,
+  net-helper, config-loader, and sleepers log-core and go-envconfig) that poison CI/CD pipelines by
+  disabling Go module verification (GOSUMDB), manipulating GOPROXY, and injecting fake 'go' wrappers
+  into PATH. The most severe Go module (go-stdlib-ext) also establishes persistent SSH backdoor access
+  by appending a hardcoded attacker-controlled ed25519 key (deploy@buildserver) to the victim's
+  authorized_keys file. Detection aggregates two signals — presence of knot-* gem directories in
+  common Ruby installation paths, and the specific attacker SSH public key in authorized_keys — into
+  a score. A score greater than 0 (any single positive indicator) triggers detection, as both signals
+  are specific enough to warrant immediate investigation. A positive result requires removal of
+  affected packages, rotation of all credentials on the system, removal of the backdoor SSH key, and
+  audit of CI/CD pipeline configurations and go.sum files.
+references:
+  - https://socket.dev/blog/malicious-ruby-gems-and-go-modules-steal-secrets-poison-ci
+author:
+  - rafa.bono@okta.com
+platform:
+  - macOS
+  - Linux
+query: |
+  WITH ruby_gems AS (
+      SELECT COALESCE(COUNT(*), 0) AS total
+      FROM file
+      WHERE path LIKE '/usr/%%/gems/knot-%'
+         OR path LIKE '/opt/%%/gems/knot-%'
+         OR path LIKE '/home/%%/gems/knot-%'
+         OR path LIKE '/Users/%%/gems/knot-%'
+  ),
+  ssh_backdoor AS (
+      SELECT COALESCE(COUNT(*), 0) AS total
+      FROM authorized_keys
+      WHERE key = 'AAAAC3NzaC1lZDI1NTE5AAAAIBp9VZGMxqFpTwKbKJi7dS2mNrX3LqEoHcYsWfAkZvUt'
+  ),
+  final_score AS (
+      SELECT
+          CASE WHEN ruby_gems.total > 0 THEN 1 ELSE 0 END
+          + CASE WHEN ssh_backdoor.total > 0 THEN 1 ELSE 0 END
+          AS score
+      FROM ruby_gems, ssh_backdoor
+  )
+  SELECT
+      CASE
+          WHEN score = 0 THEN 0
+          WHEN score > 0 THEN 1
+      END AS bufferzonecorp_campaign_detected
+  FROM final_score;

--- a/sample_osquery_checks/Cross/checkmarx_supply_chain_compromised_bitwarden_cli.yml
+++ b/sample_osquery_checks/Cross/checkmarx_supply_chain_compromised_bitwarden_cli.yml
@@ -1,19 +1,25 @@
 title: Checkmarx Supply Chain Compromised Bitwarden CLI Detection
 id: 48428b92b5034117979658613566babb
 description: |
-  Detects the presence of the compromised Bitwarden CLI npm package (@bitwarden/cli version 2026.4.0)
-  injected as part of the ongoing Checkmarx supply chain attack campaign. Attackers exploited a GitHub
-  Action in Bitwarden's CI/CD pipeline to embed a malicious payload (bw1.js) in the npm release.
-  Upon execution, the malware harvests a wide range of credentials including GitHub tokens, AWS/Azure/GCP
-  credentials, npm tokens, and SSH keys, then exfiltrates them to attacker-controlled infrastructure
-  (94.154.172.43, audit.checkmarx[.]cx/v1/telemetry) and public staging GitHub repositories with
-  Dune-themed names. It also establishes persistence by injecting payloads into shell profiles (~/.bashrc,
-  ~/.zshrc) and downloads the Bun JavaScript runtime for further payload execution. A Russian locale kill
-  switch causes the malware to exit silently on Russian-localized systems. Only the npm distribution is
-  affected — the Chrome extension, MCP server, and other Bitwarden distributions are not compromised.
-  Detection of this specific package version indicates potential credential compromise and requires
-  immediate removal of the package, rotation of all credentials present on the affected system, and
-  auditing of shell profiles for malicious injections.
+  Detects the presence of the compromised Bitwarden CLI npm package (@bitwarden/cli version
+  2026.4.0), distributed as part of the Checkmarx supply chain attack campaign. Attackers
+  exploited a GitHub Action in Bitwarden's CI/CD pipeline to embed a malicious payload
+  (bw1.js) in the npm release.
+
+  Upon execution, the malware harvests a wide range of credentials including GitHub tokens,
+  AWS/Azure/GCP credentials, npm tokens, and SSH keys. Stolen data is exfiltrated to
+  attacker-controlled infrastructure (94.154.172.43, audit.checkmarx[.]cx/v1/telemetry) and
+  public staging GitHub repositories with Dune-themed names. The malware also establishes
+  persistence by injecting payloads into shell profiles (~/.bashrc, ~/.zshrc) and downloads
+  the Bun JavaScript runtime for further payload execution. A Russian locale kill switch
+  causes the malware to exit silently on Russian-localized systems.
+
+  Only the npm distribution is affected — the Chrome extension, MCP server, and other
+  Bitwarden distributions are not compromised.
+
+  Detection of this specific package version indicates potential credential compromise and
+  requires immediate removal of the package, rotation of all credentials present on the
+  affected system, and auditing of shell profiles for malicious injections.
 references:
   - https://socket.dev/blog/bitwarden-cli-compromised
 author:

--- a/sample_osquery_checks/Cross/checkmarx_supply_chain_compromised_bitwarden_cli.yml
+++ b/sample_osquery_checks/Cross/checkmarx_supply_chain_compromised_bitwarden_cli.yml
@@ -1,0 +1,32 @@
+title: Checkmarx Supply Chain Compromised Bitwarden CLI Detection
+id: 48428b92b5034117979658613566babb
+description: |
+  Detects the presence of the compromised Bitwarden CLI npm package (@bitwarden/cli version 2026.4.0)
+  injected as part of the ongoing Checkmarx supply chain attack campaign. Attackers exploited a GitHub
+  Action in Bitwarden's CI/CD pipeline to embed a malicious payload (bw1.js) in the npm release.
+  Upon execution, the malware harvests a wide range of credentials including GitHub tokens, AWS/Azure/GCP
+  credentials, npm tokens, and SSH keys, then exfiltrates them to attacker-controlled infrastructure
+  (94.154.172.43, audit.checkmarx[.]cx/v1/telemetry) and public staging GitHub repositories with
+  Dune-themed names. It also establishes persistence by injecting payloads into shell profiles (~/.bashrc,
+  ~/.zshrc) and downloads the Bun JavaScript runtime for further payload execution. A Russian locale kill
+  switch causes the malware to exit silently on Russian-localized systems. Only the npm distribution is
+  affected — the Chrome extension, MCP server, and other Bitwarden distributions are not compromised.
+  Detection of this specific package version indicates potential credential compromise and requires
+  immediate removal of the package, rotation of all credentials present on the affected system, and
+  auditing of shell profiles for malicious injections.
+references:
+  - https://socket.dev/blog/bitwarden-cli-compromised
+author:
+  - rafa.bono@okta.com
+platform:
+  - macOS
+  - Windows
+  - Linux
+query: |
+  SELECT
+    CASE WHEN count(*) = 0 THEN '0'
+    ELSE '1'
+    END AS bitwarden_cli_compromised
+  FROM npm_packages
+  WHERE name = '@bitwarden/cli'
+    AND version = '2026.4.0';

--- a/sample_osquery_checks/Cross/malicious_chrome_extension_campaign.yml
+++ b/sample_osquery_checks/Cross/malicious_chrome_extension_campaign.yml
@@ -17,7 +17,7 @@ query: |
       ELSE '1'
     END AS chrome_malicious_extensions
   FROM chrome_extensions
-  WHERE name IN ( 
+  WHERE identifier IN ( 
         'obifanppcpchlehkjipahhphbcbjekfa', -- Telegram Multi-account
         'mdcfennpfgkngnibjbpnpaafcjnhcjno', -- Web Client for Telegram - Teleside
         'mmecpiobcdbjkaijljohghhpfgngpjmk', -- YouSide - Youtube Sidebar

--- a/sample_osquery_checks/README.md
+++ b/sample_osquery_checks/README.md
@@ -6,7 +6,7 @@ This folder contains sample osquery checks that can be used with [Okta Advanced 
 
 Advanced Posture Checks extend Okta's device assurance capabilities by letting you write your own SQL-based osquery checks instead of relying solely on built-in device attributes. When a user tries to access a protected resource, Okta Verify runs the configured osquery checks on the device and returns the results to Okta, which evaluates them against the device assurance policy before granting access.
 
-This enables enforcement of highly specific security requirements — such as the absence of known-malicious software, unauthorized tools, or compromised packages — as a condition of access. Checks run via [osquery](https://osquery.io/), a lightweight endpoint agent that exposes OS data through a SQL interface.
+This enables enforcement of highly specific security requirements, such as the absence of known-malicious software, unauthorized tools, or compromised packages; as a condition of access. Checks run via [osquery](https://osquery.io/), a lightweight endpoint agent that exposes OS data through a SQL interface.
 
 ## Folder Structure
 


### PR DESCRIPTION
## 📝 Description

This PR adds two new osquery detection checks for recent supply chain attack campaigns and updates an existing check with a field name correction.

**New detections:**
- `bufferzonecorp_campaign_detection.yml` — Detects artifacts from the BufferZoneCorp supply chain campaign, which distributes malicious Ruby gems and Go modules that steal developer credentials and establish SSH backdoor access.
- `checkmarx_supply_chain_compromised_bitwarden_cli.yml` — Detects the compromised Bitwarden CLI npm package (`@bitwarden/cli` v2026.4.0) injected as part of the Checkmarx supply chain attack.

**Updates:**
- `malicious_chrome_extension_campaign.yml` — Corrected osquery field from `name` to `identifier` in the `chrome_extensions` table query.
- `README.md` — Added `sample_osquery_checks/` to the file structure table and reformatted both Markdown tables for consistency.

## 🔗 References

- https://socket.dev/blog/malicious-ruby-gems-and-go-modules-steal-secrets-poison-ci
- https://socket.dev/blog/bitwarden-cli-compromised
- https://socket.dev/blog/108-chrome-ext-linked-to-data-exfil-session-theft-shared-c2

## 🧪 Testing

Each query was validated against the osquery schema:
- `bufferzonecorp_campaign_detection.yml` — tested against the `file` and `authorized_keys` osquery tables on macOS and Linux.
- `checkmarx_supply_chain_compromised_bitwarden_cli.yml` — tested against the `npm_packages` osquery table on macOS.
- `malicious_chrome_extension_campaign.yml` — confirmed `identifier` is the correct column name in the `chrome_extensions` osquery table (replacing the previous incorrect `name` field).

No unit test coverage exists for osquery YAML files in this repo; testing is manual.

* [ ] This change adds test coverage for new/changed/fixed functionality

## ✅ Checklist
* [x] I have added documentation for new/changed functionality in this PR or it exists in [okta.com/docs](https://help.okta.com/en-us/content/index.htm).
* [x] All active GitHub checks for tests, formatting, and security are passing.
* [x] The correct base branch is being used, if not the default branch.