### PR TITLE
Itp detections

### DIFF
--- a/detections/itp_brute_force.yml
+++ b/detections/itp_brute_force.yml
@@ -4,7 +4,7 @@ description: |
   Identity Threat Protection (ITP) has detected a push bomb or MFA fatigue attack and logged the event with
   event type user.risk.detect.
 references:
-  - https://help.okta.com/oie/en-us/content/topics/itp/risk-detections.htm
+  - https://help.okta.com/oie/en-us/content/topics/itp/detections.htm
   - https://www.okta.com/blog/2022/09/mfa-fatigue-growing-security-concern/
 author: Okta
 created_date: '2025-05-21'

--- a/detections/itp_okta_threat_intel_detection.yml
+++ b/detections/itp_okta_threat_intel_detection.yml
@@ -1,7 +1,7 @@
 title: ITP Okta Threat Intelligence Detection
 id: 4e0d20deba09d7f5e99dcdb51c6f677b
 description: |
-  Identity Threat Protection (ITP) has detected a hit against known bad infrastructure from Okta Threat Intelligence. 
+  Identity Threat Protection (ITP) has detected a hit against known bad infrastructure from Okta Threat Intelligence.
 references:
   - https://help.okta.com/oie/en-us/content/topics/itp/detections-okta-threat-intelligence.htm
 author: Okta

--- a/detections/itp_okta_threat_intel_detection.yml
+++ b/detections/itp_okta_threat_intel_detection.yml
@@ -1,0 +1,24 @@
+title: ITP Okta Threat Intelligence Detection
+id: 4e0d20deba09d7f5e99dcdb51c6f677b
+description: |
+  Identity Threat Protection (ITP) has detected a hit against known bad infrastructure from Okta Threat Intelligence. 
+references:
+  - https://help.okta.com/oie/en-us/content/topics/itp/detections-okta-threat-intelligence.htm
+author: Okta
+created_date: '2026-05-11'
+modified_date: '2026-05-11'
+threat:
+  Tactic:
+    - Initial Access
+  Technique:
+    - T1566: Phishing
+    - T1078: Valid Accounts
+prevention:
+  - Configure ITP's entity risk policy to execute universal logout and/or an Okta workflow to automatically contain/remediate the issue.
+  - Configure authentication policies to ensure phishing resistant MFA like Okta Fastpass is used in all authentication flows.
+detection:
+  okta_systemlog:
+    OIE: |
+      eventType eq "user.risk.detect" and debugContext.debugData.risk co "detectionName=Okta Threat Intelligence"
+false_positives:
+  - N/A

--- a/detections/itp_suspected_session_hijacking.yml
+++ b/detections/itp_suspected_session_hijacking.yml
@@ -1,0 +1,26 @@
+title: ITP Suspected Session Hijacking
+id: 31a02247b01948672a948400380f9568
+description: |
+  Identity Threat Protection (ITP) has detected potential session hijacking and logged the event with event type user.risk.detect.
+references:
+  - https://help.okta.com/oie/en-us/content/topics/itp/detections.htm
+  - https://help.okta.com/oie/en-us/content/topics/itp/detections-session-influenced.htm
+author: Okta
+created_date: '2026-05-11'
+modified_date: '2026-05-11'
+threat:
+  Tactic:
+    - Credential Access
+    - Collection
+  Technique:
+    - T1185: Browser Session Hijacking
+    - T1539: Steal Web Session Cookie
+prevention:
+  - Configure ITP's entity risk policy to execute universal logout if this detection is fired.
+  - Configure authentication policies to ensure phishing resistant MFA like Okta Fastpass is used in all authentication flows.
+detection:
+  okta_systemlog:
+    OIE: |
+      eventType eq "user.risk.detect" and debugContext.debugData.risk co "reasons=Associated sessionId is suspected to be hijacked"
+false_positives:
+  - Session context changes by IP from a user's telecom provider to company owned VPNs/Gateways. Exclude these in the entity risk policy.

--- a/detections/itp_user_risk_changed_to_high.yml
+++ b/detections/itp_user_risk_changed_to_high.yml
@@ -2,7 +2,7 @@ title: ITP User Risk Changed to High
 id: aeda20597eedb11a86c4334a529b763a
 description: |
   Identity Threat Protection (ITP) has elevated a user's risk to HIGH and logged the event with event type user.risk.detect.
-  This detection relies on properly configured Entity Risk Policies to elevate risk to high under certain conditions acceptable for your business. 
+  This detection relies on properly configured Entity Risk Policies to elevate risk to high under certain conditions acceptable for your business.
 references:
   - https://help.okta.com/oie/en-us/content/topics/itp/detections.htm
 author: Okta

--- a/detections/itp_user_risk_changed_to_high.yml
+++ b/detections/itp_user_risk_changed_to_high.yml
@@ -1,0 +1,24 @@
+title: ITP User Risk Changed to High
+id: aeda20597eedb11a86c4334a529b763a
+description: |
+  Identity Threat Protection (ITP) has elevated a user's risk to HIGH and logged the event with event type user.risk.detect.
+  This detection relies on properly configured Entity Risk Policies to elevate risk to high under certain conditions acceptable for your business. 
+references:
+  - https://help.okta.com/oie/en-us/content/topics/itp/detections.htm
+author: Okta
+created_date: '2026-05-11'
+modified_date: '2026-05-11'
+threat:
+  Tactic:
+    - Resource Development
+  Technique:
+    - T1586: Compromise Accounts
+prevention:
+  - Configure ITP's entity risk policy to execute universal logout and/or an Okta workflow to automatically contain/remediate the issue.
+  - Configure authentication policies to ensure phishing resistant MFA like Okta Fastpass is used in all authentication flows.
+detection:
+  okta_systemlog:
+    OIE: |
+      eventType eq "user.risk.detect" and debugContext.debugData.risk co " level=HIGH"
+false_positives:
+  - Various false positives may exist for the detections listed in the references section. Okta admins should ensure the entity risk policy is properly configured to handle these potential FPs.


### PR DESCRIPTION
Updated ITP URLs since the link was broken.

Added 3 new detections:
ITP Okta Threat Intelligence Detection: Detects when ITP flags an authentication that occurred from an IP known to Okta Threat Intelligence as malicious. 

ITP suspected session Hijacking: Detects when ITP flags an authentication deemed as potential session hijacking, typically due to session context changes. More prone to false positives and requires tuned entity risk policies. 

ITP Risk level changed to high: Detects when a user risk level changes to high, this should be alerted by the SOC for additional investigation into impact if malicious. 