### PR TITLE
Add AI tool osquery detection checks (macOS + Windows)

### DIFF
--- a/sample_osquery_checks/Windows/aider_ai_coding_agent_detection.yml
+++ b/sample_osquery_checks/Windows/aider_ai_coding_agent_detection.yml
@@ -1,0 +1,64 @@
+title: Aider AI Coding Agent Detection
+id: 8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e
+description: |
+    Detects the presence of Aider, a Python-based autonomous AI coding agent distributed via
+    pip (aider-chat). Aider is classified as high-risk by security researchers due to its use
+    of unsandboxed shell command execution (subprocess with shell=True), unrestricted filesystem
+    access, and polling of the system clipboard every 0.5 seconds which can capture sensitive
+    data. In auto-commit mode Aider can modify files and create git commits without user
+    confirmation. All code context and conversation history is transmitted to the configured
+    LLM provider (OpenAI, Anthropic, Google, etc.). Aider stores API keys in plain text in
+    ~/.aider/ configuration files, creating a secondary credential exposure risk. Note that
+    osquery has no pip/Python package table — this detection relies on binary paths in Python
+    Scripts directories, config files, prefetch entries, and process names. A score greater
+    than 1 (at least two positive indicators) is required to confirm detection.
+references:
+    - https://aider.chat
+    - https://agent-safehouse.dev/docs/agent-investigations/aider
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH file_aider AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        -- Python Scripts directories (global and user installs)
+        WHERE path LIKE '%\Scripts\aider.exe'
+            OR path LIKE '%\Users\%%\.aider\.aider.conf.yml'
+            OR path LIKE '%\Users\%%\.aider.conf.yml'
+            OR path LIKE '%\Users\%%\.aider\analytics.json'
+    ),
+    process_aider AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'aider.exe'
+            OR name = 'aider'
+            OR cmdline LIKE '%aider-chat%'
+    ),
+    prefetch_aider AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\aider%'
+    ),
+    sockets_aider AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\aider%'
+    ),
+    final_score AS (
+        SELECT
+            file_aider.total
+            + process_aider.total
+            + prefetch_aider.total
+            + sockets_aider.total
+            AS score
+        FROM file_aider, process_aider, prefetch_aider, sockets_aider
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS aider_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/aider_ai_coding_agent_detection.yml
+++ b/sample_osquery_checks/Windows/aider_ai_coding_agent_detection.yml
@@ -28,6 +28,8 @@ query: |
             OR path LIKE '%\Users\%%\.aider\.aider.conf.yml'
             OR path LIKE '%\Users\%%\.aider.conf.yml'
             OR path LIKE '%\Users\%%\.aider\analytics.json'
+            -- pipx installation
+            OR path LIKE '%\Users\%%\.local\pipx\venvs\aider-chat\%'
     ),
     process_aider AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/anythingllm_local_server_detection.yml
+++ b/sample_osquery_checks/Windows/anythingllm_local_server_detection.yml
@@ -1,0 +1,76 @@
+title: AnythingLLM Local AI Server Detection
+id: b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3
+description: |
+    Detects the presence of AnythingLLM, a desktop application and local server that enables
+    RAG (Retrieval-Augmented Generation) workflows using locally stored documents. AnythingLLM
+    can ingest and index documents, PDFs, web pages, and other data sources, then query any
+    configured LLM (local or cloud) with that context. This makes it particularly sensitive from
+    a data exposure perspective: corporate documents uploaded into AnythingLLM workspaces may be
+    chunked, embedded, and sent to external LLM APIs depending on the provider configured.
+    AnythingLLM exposes a local web server on port 3001 by default. In server mode it can be
+    accessed over the local network and provides a multi-user API without authentication by
+    default. Storage is kept in %APPDATA%\anythingllm-desktop\ including the SQLite database,
+    vector embeddings, and uploaded document contents. This detection evaluates file paths,
+    running processes, installed programs, the local server port, and prefetch entries. A score
+    greater than 1 (at least two positive indicators) is required to confirm detection.
+references:
+    - https://anythingllm.com
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH file_anyllm AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '%\Users\%%\AppData\Local\Programs\AnythingLLM Desktop\AnythingLLM Desktop.exe'
+            OR path LIKE '%\Users\%%\AppData\Roaming\anythingllm-desktop\%'
+            OR path LIKE '%\Users\%%\AppData\Local\AnythingLLM\%'
+    ),
+    process_anyllm AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%AnythingLLM%'
+            OR name LIKE '%anythingllm%'
+    ),
+    programs_anyllm AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM programs
+        WHERE name LIKE '%AnythingLLM%'
+    ),
+    netports_anyllm AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM listening_ports
+        WHERE port = '3001'
+            AND path LIKE '%AnythingLLM%'
+    ),
+    prefetch_anyllm AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\AnythingLLM%'
+            OR path LIKE '%\anythingllm%'
+    ),
+    sockets_anyllm AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\AnythingLLM%'
+    ),
+    final_score AS (
+        SELECT
+            file_anyllm.total
+            + process_anyllm.total
+            + programs_anyllm.total
+            + netports_anyllm.total
+            + prefetch_anyllm.total
+            + sockets_anyllm.total
+            AS score
+        FROM file_anyllm, process_anyllm, programs_anyllm, netports_anyllm,
+             prefetch_anyllm, sockets_anyllm
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS anythingllm_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/chatgpt_desktop_detection.yml
+++ b/sample_osquery_checks/Windows/chatgpt_desktop_detection.yml
@@ -1,0 +1,75 @@
+title: ChatGPT Desktop Detection
+id: c7e3a9f1b4d6082e5c3a7f9b1e4d6a8c
+description: |
+    Detects the presence of OpenAI's ChatGPT desktop application on Windows devices. The ChatGPT
+    desktop app provides native access to OpenAI models and includes features such as screen
+    capture, voice interaction, and file access that give the application broad visibility into
+    device activity. Conversations and any shared content are transmitted to OpenAI's servers and
+    retained according to OpenAI's data policies. The application also ships with a companion
+    background helper process that enables OS-level integrations. Organizations may wish to
+    restrict or monitor ChatGPT Desktop usage on corporate devices to ensure compliance with
+    data-handling policies. This detection evaluates startup items, file paths, running processes,
+    installed programs, and prefetch entries to identify ChatGPT Desktop installations. A score
+    greater than 1 (at least two positive indicators) is required to confirm detection.
+references:
+    - https://openai.com/chatgpt/desktop/
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH startup_chatgpt AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM startup_items
+        WHERE name LIKE '%chatgpt%'
+            OR name LIKE '%openai%'
+    ),
+    file_chatgpt AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '%\Users\%%\AppData\Local\OpenAI\ChatGPT\%'
+            OR path LIKE '%\Users\%%\AppData\Roaming\OpenAI\ChatGPT\%'
+            OR path LIKE '%\Users\%%\AppData\Local\Programs\ChatGPT\ChatGPT.exe'
+    ),
+    process_chatgpt AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%chatgpt%'
+    ),
+    programs_chatgpt AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM programs
+        WHERE name LIKE '%chatgpt%'
+            OR name LIKE '%openai%'
+    ),
+    prefetch_chatgpt AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\chatgpt%'
+            OR path LIKE '%\ChatGPT%'
+    ),
+    sockets_chatgpt AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\chatgpt%'
+            OR path LIKE '%\ChatGPT%'
+    ),
+    final_score AS (
+        SELECT
+            startup_chatgpt.total
+            + file_chatgpt.total
+            + process_chatgpt.total
+            + programs_chatgpt.total
+            + prefetch_chatgpt.total
+            + sockets_chatgpt.total
+            AS score
+        FROM startup_chatgpt, file_chatgpt, process_chatgpt, programs_chatgpt,
+             prefetch_chatgpt, sockets_chatgpt
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS chatgpt_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/claude_ai_assistant_detection.yml
+++ b/sample_osquery_checks/Windows/claude_ai_assistant_detection.yml
@@ -1,0 +1,95 @@
+title: Claude AI Assistant Detection
+id: b1c4f8e2a7d3950f6b2c8e4a1d7f3b9c
+description: |
+    Detects the presence of Anthropic's Claude AI assistant on Windows devices, covering both the
+    Claude Desktop application and the Claude Code CLI tool. Claude Desktop provides a native
+    interface for interacting with Claude models and can access local files through MCP
+    (Model Context Protocol), enabling broad system interactions. Claude Code is an agentic
+    coding tool capable of reading and modifying files, executing shell commands, and interacting
+    with external services on the user's behalf. Both tools may transmit sensitive data including
+    code, file contents, and conversation history to Anthropic's servers. This detection evaluates
+    startup items, file paths, running processes, Chocolatey packages, npm packages, installed
+    programs, prefetch entries, and active network sockets to identify Claude installations. A
+    score greater than 1 (at least two positive indicators) is required to confirm detection.
+references:
+    - https://claude.ai
+    - https://www.anthropic.com
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH startup_claude AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM startup_items
+        WHERE name LIKE '%claude%'
+            OR name LIKE '%anthropic%'
+    ),
+    file_claude AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '%\Users\%%\.claude\settings.json'
+            OR path LIKE '%\Users\%%\.claude\CLAUDE.md'
+            OR path LIKE '%\Users\%%\AppData\Local\AnthropicClaude\%'
+            OR path LIKE '%\Users\%%\AppData\Roaming\Claude\%'
+            OR path LIKE '%\Users\%%\AppData\Roaming\npm\node_modules\@anthropic-ai\claude-code\package.json'
+            OR path LIKE '%\Users\%%\node_modules\@anthropic-ai\claude-code\package.json'
+    ),
+    process_claude AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%claude%'
+            OR cmdline LIKE '%\@anthropic-ai\claude-code\%'
+            OR cmdline LIKE '%\node_modules\.bin\claude %'
+    ),
+    choco_claude AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM chocolatey_packages
+        WHERE name LIKE '%claude%'
+            OR name LIKE '%anthropic%'
+    ),
+    npm_claude AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM npm_packages
+        WHERE name LIKE '%claude%'
+            OR name LIKE '%anthropic%'
+    ),
+    programs_claude AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM programs
+        WHERE name LIKE '%claude%'
+            OR name LIKE '%anthropic%'
+    ),
+    prefetch_claude AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\claude%'
+            OR path LIKE '%\anthropic%'
+    ),
+    sockets_claude AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\claude%'
+            OR path LIKE '%\anthropic%'
+    ),
+    final_score AS (
+        SELECT
+            startup_claude.total
+            + file_claude.total
+            + process_claude.total
+            + choco_claude.total
+            + npm_claude.total
+            + programs_claude.total
+            + prefetch_claude.total
+            + sockets_claude.total
+            AS score
+        FROM startup_claude, file_claude, process_claude, choco_claude, npm_claude,
+             programs_claude, prefetch_claude, sockets_claude
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS claude_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/cline_roo_ai_agent_detection.yml
+++ b/sample_osquery_checks/Windows/cline_roo_ai_agent_detection.yml
@@ -1,0 +1,70 @@
+title: Cline / Roo-Cline AI Coding Agent Detection
+id: f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7
+description: |
+    Detects the presence of Cline (formerly Claude Dev) and its fork Roo-Cline, VS Code
+    extensions that enable fully autonomous agentic AI coding within the editor. Unlike
+    GitHub Copilot and other assistants that make suggestions, Cline/Roo-Cline are agent
+    runtimes: they can read and write any file, execute arbitrary shell commands, manage
+    browser sessions, and call MCP servers — all approved with a single up-front permission
+    grant. Roo-Cline adds additional modes (Architect, Ask, Code, Debug) and more aggressive
+    auto-approval defaults. Both extensions transmit the full content of open files, terminal
+    output, and shell command results to the configured LLM provider. API keys are stored in
+    VS Code's extension global storage. This detection covers both Cline and Roo-Cline across
+    VS Code and Cursor extension directories, as well as VS Code global storage confirming
+    active use. A score greater than 1 (at least two positive indicators) is required to
+    confirm detection.
+references:
+    - https://github.com/cline/cline
+    - https://github.com/RooVetGit/Roo-Code
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH file_cline AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        -- VS Code extension directories (Cline and Roo-Cline)
+        WHERE path LIKE '%\Users\%%\.vscode\extensions\saoudrizwan.claude-dev-%'
+            OR path LIKE '%\Users\%%\.vscode\extensions\rooveterinaryinc.roo-cline-%'
+            -- Cursor extension directories
+            OR path LIKE '%\Users\%%\.cursor\extensions\saoudrizwan.claude-dev-%'
+            OR path LIKE '%\Users\%%\.cursor\extensions\rooveterinaryinc.roo-cline-%'
+            -- VS Code global storage confirms active usage
+            OR path LIKE '%\Users\%%\AppData\Roaming\Code\User\globalStorage\saoudrizwan.claude-dev\%'
+            OR path LIKE '%\Users\%%\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\%'
+    ),
+    process_cline AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE cmdline LIKE '%saoudrizwan.claude-dev%'
+            OR cmdline LIKE '%rooveterinaryinc.roo-cline%'
+    ),
+    prefetch_cline AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%saoudrizwan.claude-dev%'
+            OR path LIKE '%rooveterinaryinc.roo-cline%'
+    ),
+    sockets_cline AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%saoudrizwan.claude-dev%'
+            OR path LIKE '%rooveterinaryinc.roo-cline%'
+    ),
+    final_score AS (
+        SELECT
+            file_cline.total
+            + process_cline.total
+            + prefetch_cline.total
+            + sockets_cline.total
+            AS score
+        FROM file_cline, process_cline, prefetch_cline, sockets_cline
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS cline_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/continue_dev_ai_coding_assistant_detection.yml
+++ b/sample_osquery_checks/Windows/continue_dev_ai_coding_assistant_detection.yml
@@ -1,0 +1,75 @@
+title: Continue.dev AI Coding Assistant Detection
+id: 4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e
+description: |
+    Detects the presence of Continue.dev, an open-source AI coding assistant extension for VS
+    Code and JetBrains IDEs. Unlike single-provider tools such as GitHub Copilot, Continue.dev
+    acts as a universal proxy that can route editor queries to any configured LLM provider —
+    including local models (Ollama, LM Studio, Jan.ai), OpenAI, Anthropic, Google, and any
+    OpenAI-compatible API. Its MCP (Model Context Protocol) support enables deep tool
+    integrations: the extension can be configured to give the model access to the local
+    filesystem, terminal, databases, and external APIs directly from the IDE. The primary
+    configuration file (%USERPROFILE%\.continue\config.yaml or config.json) is stored in
+    plaintext and may contain API keys for multiple LLM providers. Any secrets placed here
+    are readable by any process with user-level access on the device. This detection evaluates
+    the Continue.dev configuration directory, VS Code extension installation, and the
+    background language server process launched by the extension. A score greater than 1
+    (at least two positive indicators) is required to confirm detection.
+references:
+    - https://continue.dev
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH file_continue AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '%\Users\%%\.continue\config.yaml'
+            OR path LIKE '%\Users\%%\.continue\config.json'
+            OR path LIKE '%\Users\%%\.continue\config.ts'
+            -- VS Code extension directory
+            OR path LIKE '%\Users\%%\.vscode\extensions\continue.continue-%'
+    ),
+    process_continue AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        -- Language server spawned by the VS Code extension
+        WHERE cmdline LIKE '%\continue.continue-%\out\extension%'
+            OR cmdline LIKE '%\.continue\bin\%'
+            OR name = 'continue-binary.exe'
+    ),
+    npm_continue AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM npm_packages
+        WHERE name LIKE '%continuedev%'
+            OR name LIKE '%@continuedev%'
+    ),
+    prefetch_continue AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\continue-binary%'
+            OR path LIKE '%\continuedev%'
+    ),
+    sockets_continue AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\continue-binary%'
+            OR path LIKE '%\continuedev%'
+    ),
+    final_score AS (
+        SELECT
+            file_continue.total
+            + process_continue.total
+            + npm_continue.total
+            + prefetch_continue.total
+            + sockets_continue.total
+            AS score
+        FROM file_continue, process_continue, npm_continue, prefetch_continue, sockets_continue
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS continue_dev_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/cursor_ai_editor_detection.yml
+++ b/sample_osquery_checks/Windows/cursor_ai_editor_detection.yml
@@ -1,0 +1,83 @@
+title: Cursor AI Editor Detection
+id: f9a4c1e6b3d7580f2a4c1e6b3d7f5c0f
+description: |
+    Detects the presence of Cursor, an AI-native code editor built on VS Code, on Windows
+    devices. Cursor embeds AI coding assistance directly into the editor and by default sends
+    code context — including open files, terminal output, and repository history — to Cursor's
+    servers and third-party AI providers (OpenAI, Anthropic, Google). The editor's Agent mode
+    can autonomously execute code, run terminal commands, and modify files without per-action
+    confirmation. Privacy mode is available but requires explicit opt-in. Organizations may wish
+    to audit Cursor usage on corporate devices to assess data exposure and enforce approved AI
+    tooling policies. This detection evaluates startup items, file paths, running processes,
+    Chocolatey packages, installed programs, and prefetch entries to identify Cursor
+    installations. A score greater than 1 (at least two positive indicators) is required to
+    confirm detection.
+references:
+    - https://cursor.com
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH startup_cursor AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM startup_items
+        WHERE name LIKE '%cursor%'
+    ),
+    file_cursor AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '%\Users\%%\AppData\Local\Programs\cursor\Cursor.exe'
+            OR path LIKE '%\Users\%%\AppData\Local\cursor\%'
+            OR path LIKE '%\Users\%%\.cursor\mcp.json'
+            OR path LIKE '%\Users\%%\AppData\Roaming\Cursor\User\settings.json'
+    ),
+    process_cursor AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%cursor%'
+            AND path NOT LIKE '%\Windows\%'
+            AND path NOT LIKE '%\System32\%'
+    ),
+    choco_cursor AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM chocolatey_packages
+        WHERE name LIKE '%cursor%'
+    ),
+    programs_cursor AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM programs
+        WHERE name LIKE '%cursor%'
+            AND name NOT LIKE '%Microsoft%'
+    ),
+    prefetch_cursor AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\Programs\cursor\%'
+            OR path LIKE '%\cursor\Cursor.exe%'
+    ),
+    sockets_cursor AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\Programs\cursor\%'
+    ),
+    final_score AS (
+        SELECT
+            startup_cursor.total
+            + file_cursor.total
+            + process_cursor.total
+            + choco_cursor.total
+            + programs_cursor.total
+            + prefetch_cursor.total
+            + sockets_cursor.total
+            AS score
+        FROM startup_cursor, file_cursor, process_cursor, choco_cursor, programs_cursor,
+             prefetch_cursor, sockets_cursor
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS cursor_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/gemini_cli_detection.yml
+++ b/sample_osquery_checks/Windows/gemini_cli_detection.yml
@@ -1,0 +1,78 @@
+title: Gemini CLI AI Coding Agent Detection
+id: 7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d
+description: |
+    Detects the presence of Google's Gemini CLI, an agentic AI coding assistant distributed as
+    an npm package (@google/gemini-cli). Gemini CLI is the Google equivalent of Claude Code and
+    OpenAI Codex CLI — it can autonomously read and write files, execute shell commands, run
+    tests, search the web, and interact with MCP servers on the user's behalf. All interactions
+    and code context, including file contents and command outputs, are transmitted to Google's
+    Gemini API. The tool authenticates via Google OAuth, linking activity to the user's Google
+    account and potentially to Google Workspace data. Organizations with Google Workspace should
+    evaluate whether Gemini CLI usage is covered by their existing data-processing agreements
+    with Google. This detection evaluates file paths, running processes, npm packages, and
+    Chocolatey installations to identify Gemini CLI presence. Local project installs are covered
+    via node_modules path matching. A score greater than 1 (at least two positive indicators)
+    is required to confirm detection.
+references:
+    - https://github.com/google-gemini/gemini-cli
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH file_gemini AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '%\Users\%%\AppData\Roaming\GeminiCli\settings.json'
+            OR path LIKE '%\Users\%%\AppData\Roaming\npm\node_modules\@google\gemini-cli\package.json'
+            OR path LIKE '%\Users\%%\node_modules\@google\gemini-cli\package.json'
+            OR path LIKE '%\Users\%%\AppData\Roaming\npm\gemini'
+    ),
+    process_gemini AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'gemini.exe'
+            OR name = 'gemini'
+            OR cmdline LIKE '%\@google\gemini-cli\%'
+            OR cmdline LIKE '%\node_modules\.bin\gemini %'
+    ),
+    choco_gemini AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM chocolatey_packages
+        WHERE name = 'gemini-cli'
+    ),
+    npm_gemini AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM npm_packages
+        WHERE name LIKE '%google/gemini-cli%'
+            OR name = 'gemini-cli'
+    ),
+    prefetch_gemini AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\gemini%'
+    ),
+    sockets_gemini AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\gemini%'
+    ),
+    final_score AS (
+        SELECT
+            file_gemini.total
+            + process_gemini.total
+            + choco_gemini.total
+            + npm_gemini.total
+            + prefetch_gemini.total
+            + sockets_gemini.total
+            AS score
+        FROM file_gemini, process_gemini, choco_gemini, npm_gemini,
+             prefetch_gemini, sockets_gemini
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS gemini_cli_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/github_copilot_detection.yml
+++ b/sample_osquery_checks/Windows/github_copilot_detection.yml
@@ -1,0 +1,75 @@
+title: GitHub Copilot Detection
+id: e2d7f3b0c5a8274f9e2d7f3b0c5a8b4e
+description: |
+    Detects the presence of GitHub Copilot on Windows devices, including the VS Code extension,
+    the Copilot language server, and the Copilot CLI. GitHub Copilot transmits code context
+    from the active editor — including open files, surrounding code, and repository history —
+    to GitHub's servers for AI completion. The Copilot CLI extends this capability to shell
+    commands and git operations. Organizations subject to strict data residency or IP protection
+    requirements may wish to control or audit Copilot usage on corporate devices. This detection
+    evaluates file paths (VS Code extension directory, credential and config files), running
+    processes, npm packages, and prefetch entries to identify GitHub Copilot installations. A
+    score greater than 1 (at least two positive indicators) is required to confirm detection.
+references:
+    - https://github.com/features/copilot
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH file_copilot AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '%\Users\%%\.vscode\extensions\github.copilot-%'
+            OR path LIKE '%\Users\%%\.vscode\extensions\github.copilot-chat-%'
+            OR path LIKE '%\Users\%%\.config\github-copilot\hosts.json'
+            OR path LIKE '%\Users\%%\.config\github-copilot\apps.json'
+            OR path LIKE '%\Users\%%\AppData\Roaming\npm\node_modules\@github\copilot-language-server\package.json'
+            OR path LIKE '%\Users\%%\node_modules\@github\copilot-language-server\package.json'
+    ),
+    process_copilot AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%copilot%'
+            OR cmdline LIKE '%\copilot-language-server%'
+            OR cmdline LIKE '%\@github\copilot%'
+    ),
+    npm_copilot AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM npm_packages
+        WHERE name LIKE '%copilot%'
+    ),
+    choco_copilot AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM chocolatey_packages
+        WHERE name LIKE '%copilot%'
+    ),
+    prefetch_copilot AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\copilot%'
+    ),
+    sockets_copilot AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\copilot%'
+    ),
+    final_score AS (
+        SELECT
+            file_copilot.total
+            + process_copilot.total
+            + npm_copilot.total
+            + choco_copilot.total
+            + prefetch_copilot.total
+            + sockets_copilot.total
+            AS score
+        FROM file_copilot, process_copilot, npm_copilot, choco_copilot,
+             prefetch_copilot, sockets_copilot
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS copilot_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/goose_ai_agent_detection.yml
+++ b/sample_osquery_checks/Windows/goose_ai_agent_detection.yml
@@ -1,0 +1,66 @@
+title: Goose AI Agent Detection (Block)
+id: b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7
+description: |
+    Detects the presence of Goose, an open-source autonomous AI software engineering agent
+    developed by Block (formerly Square). Goose is a command-line agent that can read and write
+    files, execute shell commands, browse the web, interact with APIs, and chain together complex
+    multi-step tasks on the user's behalf. Unlike tools limited to code completion, Goose is
+    designed for end-to-end task automation: it can manage git repositories, run test suites,
+    modify build pipelines, and call external services — all without per-action confirmation in
+    default configuration. Goose supports MCP (Model Context Protocol) extensions and can be
+    configured to use any LLM provider including local models via Ollama, significantly expanding
+    the tools it can call and the data it can access. Configuration profiles are stored in plain
+    text at %APPDATA%\goose\profiles.yaml and may contain API keys. Session transcripts are
+    written to %LOCALAPPDATA%\goose\sessions\ and can contain sensitive code context. This
+    detection evaluates binary paths, config files, session data, running processes, and prefetch
+    entries. A score greater than 1 (at least two positive indicators) is required to confirm
+    detection.
+references:
+    - https://block.github.io/goose
+    - https://github.com/block/goose
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH file_goose AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '%\Users\%%\.local\bin\goose.exe'
+            OR path LIKE '%\Users\%%\AppData\Roaming\goose\profiles.yaml'
+            OR path LIKE '%\Users\%%\AppData\Roaming\goose\config.yaml'
+            OR path LIKE '%\Users\%%\AppData\Local\goose\sessions\%'
+    ),
+    process_goose AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'goose.exe'
+            OR name = 'goose'
+            OR cmdline LIKE '%block-goose%'
+    ),
+    prefetch_goose AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\goose.exe%'
+    ),
+    sockets_goose AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\goose.exe'
+    ),
+    final_score AS (
+        SELECT
+            file_goose.total
+            + process_goose.total
+            + prefetch_goose.total
+            + sockets_goose.total
+            AS score
+        FROM file_goose, process_goose, prefetch_goose, sockets_goose
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS goose_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/gpt4all_local_llm_detection.yml
+++ b/sample_osquery_checks/Windows/gpt4all_local_llm_detection.yml
@@ -1,0 +1,75 @@
+title: GPT4All Local LLM Detection
+id: f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1
+description: |
+    Detects the presence of GPT4All, a desktop application for running open-source language models
+    locally, developed by Nomic AI. GPT4All downloads and stores model weight files on the device
+    (typically in %LOCALAPPDATA%\nomic.ai\GPT4All\) and provides both a graphical interface and
+    an optional local API server on port 4891. The API server is OpenAI-compatible and, when
+    enabled, allows any local process to query the model without authentication. As with other
+    local LLM solutions, inference happens entirely on-device, making cloud-based DLP controls
+    blind to data sent through GPT4All. Organizations should assess whether GPT4All constitutes
+    an approved local inference solution and whether the local API server (if enabled) poses a
+    lateral movement risk. This detection evaluates file paths, running processes, installed
+    programs, the local API port, and prefetch entries. A score greater than 1 (at least two
+    positive indicators) is required to confirm detection.
+references:
+    - https://gpt4all.io
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH file_gpt4all AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '%\Users\%%\AppData\Local\Programs\GPT4All\GPT4All.exe'
+            OR path LIKE '%\Users\%%\AppData\Local\nomic.ai\GPT4All\%'
+            OR path LIKE '%\Users\%%\AppData\Local\GPT4All\%'
+    ),
+    process_gpt4all AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%GPT4All%'
+            OR name LIKE '%gpt4all%'
+    ),
+    programs_gpt4all AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM programs
+        WHERE name LIKE '%GPT4All%'
+    ),
+    netports_gpt4all AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM listening_ports
+        WHERE port = '4891'
+            AND path LIKE '%GPT4All%'
+    ),
+    prefetch_gpt4all AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\GPT4All%'
+            OR path LIKE '%\gpt4all%'
+    ),
+    sockets_gpt4all AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\GPT4All%'
+    ),
+    final_score AS (
+        SELECT
+            file_gpt4all.total
+            + process_gpt4all.total
+            + programs_gpt4all.total
+            + netports_gpt4all.total
+            + prefetch_gpt4all.total
+            + sockets_gpt4all.total
+            AS score
+        FROM file_gpt4all, process_gpt4all, programs_gpt4all, netports_gpt4all,
+             prefetch_gpt4all, sockets_gpt4all
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS gpt4all_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/jan_ai_local_llm_detection.yml
+++ b/sample_osquery_checks/Windows/jan_ai_local_llm_detection.yml
@@ -1,0 +1,84 @@
+title: Jan.ai Local LLM Detection
+id: 2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c
+description: |
+    Detects the presence of Jan.ai, an open-source desktop application for running large
+    language models entirely on-device. Jan.ai downloads and stores model weight files in
+    %USERPROFILE%\.jan\models\ and provides an OpenAI-compatible API server on port 1337
+    (the "Jan API Server"). The local server can be accessed by any application on the device
+    or, if the user changes the bind address, from the local network. As with other local LLM
+    servers (Ollama, LM Studio), all inference happens locally so outbound DLP controls have
+    no visibility into data processed by Jan.ai. Jan.ai additionally supports MCP (Model
+    Context Protocol) tool integrations that can grant local AI models access to the
+    filesystem, shell, and other device resources. Organizations should classify Jan.ai under
+    the same risk category as Ollama and LM Studio. This detection evaluates startup items,
+    file paths, running processes, installed programs, listening ports, and prefetch entries.
+    A score greater than 1 (at least two positive indicators) is required to confirm detection.
+references:
+    - https://jan.ai
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH startup_jan AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM startup_items
+        WHERE name LIKE '%jan%'
+    ),
+    file_jan AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '%\Users\%%\AppData\Local\Programs\Jan\Jan.exe'
+            OR path LIKE '%\Users\%%\.jan\models\%'
+            OR path LIKE '%\Users\%%\.jan\settings.json'
+            OR path LIKE '%\Users\%%\AppData\Roaming\Jan\%'
+    ),
+    process_jan AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'Jan.exe'
+            OR name LIKE '%jan-ai%'
+    ),
+    programs_jan AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM programs
+        WHERE name LIKE '%Jan%'
+            AND name NOT LIKE '%January%'
+    ),
+    netports_jan AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM listening_ports
+        WHERE port = '1337'
+            AND path LIKE '%Jan%'
+    ),
+    prefetch_jan AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\Jan\Jan.exe%'
+            OR path LIKE '%\jan-ai%'
+    ),
+    sockets_jan AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\Jan\Jan.exe'
+    ),
+    final_score AS (
+        SELECT
+            startup_jan.total
+            + file_jan.total
+            + process_jan.total
+            + programs_jan.total
+            + netports_jan.total
+            + prefetch_jan.total
+            + sockets_jan.total
+            AS score
+        FROM startup_jan, file_jan, process_jan, programs_jan,
+             netports_jan, prefetch_jan, sockets_jan
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS jan_ai_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/kiro_amazon_q_detection.yml
+++ b/sample_osquery_checks/Windows/kiro_amazon_q_detection.yml
@@ -1,0 +1,82 @@
+title: Kiro (Amazon Q) AI Developer Tool Detection
+id: 6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c
+description: |
+    Detects the presence of Kiro, AWS's AI-powered developer tool and successor to Amazon Q
+    Developer CLI. Kiro is an agentic coding assistant with deep AWS integration that can read
+    and modify files, execute shell commands, run tests, and interact directly with AWS services
+    and credentials available on the device. Its MCP (Model Context Protocol) support enables
+    broad tool integrations including access to databases, APIs, and cloud infrastructure.
+    Because Kiro authenticates through AWS IAM Identity Center, a compromised or misconfigured
+    Kiro session may have the same AWS permissions as the authenticated user, including access
+    to production secrets. This detection also covers residual Amazon Q Developer artifacts
+    (config stored in %USERPROFILE%\.amazonq\) that persist during the Q-to-Kiro migration.
+    Detection evaluates startup items, file paths, running processes, installed programs, and
+    prefetch entries. A score greater than 1 (at least two positive indicators) is required to
+    confirm detection.
+references:
+    - https://kiro.dev
+    - https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/upgrade-to-kiro.html
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH startup_kiro AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM startup_items
+        WHERE name LIKE '%kiro%'
+            OR name LIKE '%amazon-q%'
+    ),
+    file_kiro AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '%\Users\%%\AppData\Local\Programs\Kiro\Kiro.exe'
+            OR path LIKE '%\Users\%%\.kiro\settings\cli.json'
+            OR path LIKE '%\Users\%%\.kiro\settings\mcp.json'
+            -- Legacy Amazon Q Developer paths (pre-migration)
+            OR path LIKE '%\Users\%%\.amazonq\scopes\scope.json'
+            -- AWS Toolkit VS Code extension (ships Kiro/Q integration)
+            OR path LIKE '%\Users\%%\.vscode\extensions\amazonwebservices.aws-toolkit-vscode-%'
+    ),
+    process_kiro AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%kiro%'
+            OR name LIKE '%amazon-q%'
+            OR cmdline LIKE '%kiro-cli%'
+    ),
+    programs_kiro AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM programs
+        WHERE name LIKE '%kiro%'
+            OR name LIKE '%amazon q%'
+    ),
+    prefetch_kiro AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\kiro%'
+            OR path LIKE '%\amazon-q%'
+    ),
+    sockets_kiro AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\kiro%'
+    ),
+    final_score AS (
+        SELECT
+            startup_kiro.total
+            + file_kiro.total
+            + process_kiro.total
+            + programs_kiro.total
+            + prefetch_kiro.total
+            + sockets_kiro.total
+            AS score
+        FROM startup_kiro, file_kiro, process_kiro, programs_kiro, prefetch_kiro, sockets_kiro
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS kiro_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/kiro_amazon_q_detection.yml
+++ b/sample_osquery_checks/Windows/kiro_amazon_q_detection.yml
@@ -37,6 +37,8 @@ query: |
             OR path LIKE '%\Users\%%\.amazonq\scopes\scope.json'
             -- AWS Toolkit VS Code extension (ships Kiro/Q integration)
             OR path LIKE '%\Users\%%\.vscode\extensions\amazonwebservices.aws-toolkit-vscode-%'
+            -- Legacy Amazon Q CLI binary (named q)
+            OR path LIKE '%\Users\%%\.local\bin\q.exe'
     ),
     process_kiro AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/llamacpp_inference_server_detection.yml
+++ b/sample_osquery_checks/Windows/llamacpp_inference_server_detection.yml
@@ -1,0 +1,79 @@
+title: llama.cpp Inference Server Detection
+id: d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5
+description: |
+    Detects the presence of llama.cpp, a C++ runtime for running quantized LLM models locally.
+    llama.cpp is the foundational inference engine underlying many local AI tools and provides
+    llama-server, a standalone HTTP server exposing an OpenAI-compatible API on port 8080.
+    When llama-server is running, any process on the device or local network can submit
+    completions requests, process arbitrary text through the loaded model, and retrieve model
+    configuration — with no authentication by default. On Windows, llama.cpp binaries are
+    typically compiled from source, distributed as GitHub release archives, or installed via
+    Chocolatey. Unlike desktop apps, llama.cpp leaves minimal GUI artifacts and may run
+    headlessly as a background server accessible from the network. This detection evaluates
+    binary paths, Chocolatey package presence, running processes, the default inference port,
+    and prefetch entries. A score greater than 1 (at least two positive indicators) is required
+    to confirm detection.
+references:
+    - https://github.com/ggml-org/llama.cpp
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH file_llamacpp AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '%\llama-server.exe'
+            OR path LIKE '%\llama-cli.exe'
+            OR path LIKE '%\llama.cpp\%'
+    ),
+    process_llamacpp AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'llama-server.exe'
+            OR name = 'llama-cli.exe'
+            OR name = 'llama-server'
+    ),
+    choco_llamacpp AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM chocolatey_packages
+        WHERE name = 'llama.cpp'
+            OR name LIKE '%llamacpp%'
+    ),
+    netports_llamacpp AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM listening_ports
+        WHERE port = '8080'
+            AND path LIKE '%llama%'
+    ),
+    prefetch_llamacpp AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\llama-server%'
+            OR path LIKE '%\llama-cli%'
+    ),
+    sockets_llamacpp AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\llama-server%'
+            OR path LIKE '%\llama-cli%'
+    ),
+    final_score AS (
+        SELECT
+            file_llamacpp.total
+            + process_llamacpp.total
+            + choco_llamacpp.total
+            + netports_llamacpp.total
+            + prefetch_llamacpp.total
+            + sockets_llamacpp.total
+            AS score
+        FROM file_llamacpp, process_llamacpp, choco_llamacpp, netports_llamacpp,
+             prefetch_llamacpp, sockets_llamacpp
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS llamacpp_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/lm_studio_local_llm_detection.yml
+++ b/sample_osquery_checks/Windows/lm_studio_local_llm_detection.yml
@@ -1,0 +1,85 @@
+title: LM Studio Local LLM Detection
+id: 0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a
+description: |
+    Detects the presence of LM Studio, a desktop application for running open-source language
+    models locally. Like Ollama, LM Studio downloads and stores large model weight files on
+    the device and exposes an OpenAI-compatible REST API on port 1234. Any application or user
+    on the same machine — or the local network if bound to 0.0.0.0 — can query the local model
+    without authentication. Because inference happens locally, cloud-based DLP controls that
+    inspect outbound API traffic will not detect data sent through LM Studio. Model weight files
+    can be several gigabytes and represent a significant storage and data-exfiltration surface.
+    On Windows, LM Studio installs to %LOCALAPPDATA%\Programs\LM Studio\ and stores models in
+    %USERPROFILE%\.lmstudio\models\. Organizations should assess whether local LLM serving is
+    an approved activity before allowing LM Studio to be installed. This detection evaluates
+    startup items, file paths, running processes, installed programs, listening ports, and
+    prefetch entries. A score greater than 1 (at least two positive indicators) is required to
+    confirm detection.
+references:
+    - https://lmstudio.ai
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH startup_lmstudio AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM startup_items
+        WHERE name LIKE '%LM Studio%'
+            OR name LIKE '%lmstudio%'
+    ),
+    file_lmstudio AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '%\Users\%%\AppData\Local\Programs\LM Studio\LM Studio.exe'
+            OR path LIKE '%\Users\%%\.lmstudio\models\%'
+            OR path LIKE '%\Users\%%\.lmstudio\config.json'
+            OR path LIKE '%\Users\%%\AppData\Roaming\LM Studio\%'
+    ),
+    process_lmstudio AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%LM Studio%'
+            OR name LIKE '%lmstudio%'
+    ),
+    programs_lmstudio AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM programs
+        WHERE name LIKE '%LM Studio%'
+    ),
+    netports_lmstudio AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM listening_ports
+        WHERE port = '1234'
+            AND path LIKE '%LM Studio%'
+    ),
+    prefetch_lmstudio AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\LM Studio%'
+            OR path LIKE '%\lmstudio%'
+    ),
+    sockets_lmstudio AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\LM Studio%'
+    ),
+    final_score AS (
+        SELECT
+            startup_lmstudio.total
+            + file_lmstudio.total
+            + process_lmstudio.total
+            + programs_lmstudio.total
+            + netports_lmstudio.total
+            + prefetch_lmstudio.total
+            + sockets_lmstudio.total
+            AS score
+        FROM startup_lmstudio, file_lmstudio, process_lmstudio, programs_lmstudio,
+             netports_lmstudio, prefetch_lmstudio, sockets_lmstudio
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS lmstudio_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/microsoft_copilot_detection.yml
+++ b/sample_osquery_checks/Windows/microsoft_copilot_detection.yml
@@ -1,0 +1,80 @@
+title: Microsoft Copilot Detection
+id: 5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f
+description: |
+    Detects the presence of Microsoft Copilot, the AI assistant built into Windows 11 and
+    later releases. Microsoft Copilot is pre-installed on Windows 11 and Windows 12 systems
+    and deeply integrated into the operating system: it has access to the user's Microsoft
+    account, can read open windows and clipboard contents, and is capable of executing actions
+    on the user's behalf including sending emails, creating calendar events, and interacting
+    with Microsoft 365 apps. Unlike optional third-party AI tools, Copilot is distributed as
+    a Windows Store app (MSIX package under %LOCALAPPDATA%\Packages\Microsoft.Copilot_*)
+    and is difficult to fully disable without Group Policy. All conversations are transmitted
+    to Microsoft's cloud services. Organizations that have not configured a Microsoft 365
+    Copilot enterprise license may still have the consumer version active unless explicitly
+    disabled through MDM or Group Policy. This detection evaluates the MSIX package directory,
+    startup items, running processes, installed programs, and prefetch entries. A score greater
+    than 1 (at least two positive indicators) is required to confirm detection.
+references:
+    - https://support.microsoft.com/en-us/copilot
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH file_mscopilot AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        -- MSIX/UWP package store path
+        WHERE path LIKE '%\Users\%%\AppData\Local\Packages\Microsoft.Copilot_%'
+            OR path LIKE '%\Users\%%\AppData\Local\Microsoft\WindowsApps\Copilot.exe'
+    ),
+    startup_mscopilot AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM startup_items
+        WHERE name LIKE '%Copilot%'
+            AND name NOT LIKE '%GitHub Copilot%'
+    ),
+    process_mscopilot AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE (name LIKE '%Copilot%' OR name = 'Microsoft.Copilot.exe')
+            AND path NOT LIKE '%\GitHub\%'
+            AND path NOT LIKE '%\Extensions\%'
+    ),
+    programs_mscopilot AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM programs
+        WHERE name LIKE '%Microsoft Copilot%'
+            OR name = 'Copilot'
+    ),
+    prefetch_mscopilot AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE (path LIKE '%\Copilot.exe%' OR path LIKE '%\Microsoft.Copilot%')
+            AND path NOT LIKE '%GitHub%'
+    ),
+    sockets_mscopilot AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE (path LIKE '%\Copilot.exe' OR path LIKE '%\Microsoft.Copilot%')
+            AND path NOT LIKE '%GitHub%'
+    ),
+    final_score AS (
+        SELECT
+            file_mscopilot.total
+            + startup_mscopilot.total
+            + process_mscopilot.total
+            + programs_mscopilot.total
+            + prefetch_mscopilot.total
+            + sockets_mscopilot.total
+            AS score
+        FROM file_mscopilot, startup_mscopilot, process_mscopilot, programs_mscopilot,
+             prefetch_mscopilot, sockets_mscopilot
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS ms_copilot_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/ollama_local_llm_server_detection.yml
+++ b/sample_osquery_checks/Windows/ollama_local_llm_server_detection.yml
@@ -1,0 +1,87 @@
+title: Ollama Local LLM Server Detection
+id: 5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b
+description: |
+    Detects the presence of Ollama, a local LLM server that runs open-source language models
+    (Llama, Mistral, Gemma, etc.) directly on the device. Ollama exposes a REST API on port
+    11434 that by default binds to 0.0.0.0, making it accessible to any machine on the local
+    network without authentication. Any process or network peer can query the model, retrieve
+    loaded model weights, and use the API to process arbitrary text — including sensitive
+    corporate data. Because inference happens locally, outbound data-loss-prevention controls
+    that inspect cloud API traffic will not detect data sent through Ollama. On Windows, Ollama
+    installs a background service and an auto-updater that run at startup. Organizations should
+    assess whether local LLM serving is an approved activity and ensure the OLLAMA_HOST
+    environment variable is restricted to 127.0.0.1 on shared or networked devices. This
+    detection evaluates startup items, file paths, running processes, Chocolatey packages,
+    installed programs, listening ports, and prefetch entries. A score greater than 1 (at least
+    two positive indicators) is required to confirm detection.
+references:
+    - https://ollama.com
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH startup_ollama AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM startup_items
+        WHERE name LIKE '%ollama%'
+    ),
+    file_ollama AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '%\Users\%%\AppData\Local\Programs\Ollama\ollama.exe'
+            OR path LIKE '%\Users\%%\AppData\Local\Ollama\%'
+            OR path LIKE '%\Users\%%\.ollama\models\%'
+    ),
+    process_ollama AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%ollama%'
+    ),
+    choco_ollama AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM chocolatey_packages
+        WHERE name = 'ollama'
+    ),
+    programs_ollama AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM programs
+        WHERE name LIKE '%ollama%'
+    ),
+    netports_ollama AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM listening_ports
+        WHERE port = '11434'
+            OR path LIKE '%ollama%'
+    ),
+    prefetch_ollama AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\ollama%'
+    ),
+    sockets_ollama AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\ollama%'
+    ),
+    final_score AS (
+        SELECT
+            startup_ollama.total
+            + file_ollama.total
+            + process_ollama.total
+            + choco_ollama.total
+            + programs_ollama.total
+            + netports_ollama.total
+            + prefetch_ollama.total
+            + sockets_ollama.total
+            AS score
+        FROM startup_ollama, file_ollama, process_ollama, choco_ollama, programs_ollama,
+             netports_ollama, prefetch_ollama, sockets_ollama
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS ollama_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/openai_codex_cli_detection.yml
+++ b/sample_osquery_checks/Windows/openai_codex_cli_detection.yml
@@ -1,0 +1,67 @@
+title: OpenAI Codex CLI Detection
+id: d4b9e2c7f0a5163f8d4b0e2c7f9a5b1d
+description: |
+    Detects the presence of the OpenAI Codex CLI tool on Windows devices. Codex is an interactive
+    agentic coding assistant distributed as an npm package (@openai/codex) that can autonomously
+    read and write files, execute shell commands, and interact with external services on the
+    user's behalf. When running in auto-approval mode the tool requires no user confirmation
+    before taking actions, which can include modifying source code, running tests, and making
+    network requests. All interactions and code context are transmitted to OpenAI's API. This
+    detection evaluates file paths, running processes, npm package installations, and prefetch
+    entries to identify Codex CLI installations. A score greater than 1 (at least two positive
+    indicators) is required to confirm detection.
+references:
+    - https://github.com/openai/codex
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH file_codex AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '%\Users\%%\.codex\config.json'
+            OR path LIKE '%\Users\%%\AppData\Roaming\npm\node_modules\@openai\codex\package.json'
+            OR path LIKE '%\Users\%%\node_modules\@openai\codex\package.json'
+    ),
+    process_codex AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'codex.exe'
+            OR name = 'codex'
+            OR cmdline LIKE '%\@openai\codex\%'
+            OR cmdline LIKE '%\node_modules\.bin\codex %'
+    ),
+    npm_codex AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM npm_packages
+        WHERE name LIKE '%openai/codex%'
+            OR name = 'codex'
+    ),
+    prefetch_codex AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\codex%'
+    ),
+    sockets_codex AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\codex%'
+    ),
+    final_score AS (
+        SELECT
+            file_codex.total
+            + process_codex.total
+            + npm_codex.total
+            + prefetch_codex.total
+            + sockets_codex.total
+            AS score
+        FROM file_codex, process_codex, npm_codex, prefetch_codex, sockets_codex
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS codex_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/opencode_ai_agent_detection.yml
+++ b/sample_osquery_checks/Windows/opencode_ai_agent_detection.yml
@@ -1,0 +1,70 @@
+title: OpenCode AI Coding Agent Detection
+id: d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9
+description: |
+    Detects the presence of OpenCode, an open-source terminal-based AI coding agent distributed
+    as an npm package (opencode-ai). OpenCode is a CLI-first agentic tool similar to Claude Code
+    and Gemini CLI — it can autonomously read and write files, execute shell commands, run tests,
+    and interact with MCP servers on the user's behalf. All code context and conversation history
+    is transmitted to the configured LLM provider (OpenAI, Anthropic, AWS Bedrock, or others).
+    OpenCode stores its configuration in %APPDATA%\opencode\ and supports project-level agent
+    instruction files (AGENTS.md). This detection evaluates binary paths, npm package presence,
+    config files, running processes, and prefetch entries. A score greater than 1 (at least two
+    positive indicators) is required to confirm detection.
+references:
+    - https://opencode.ai
+    - https://github.com/sst/opencode
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH file_opencode AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '%\Users\%%\AppData\Roaming\npm\opencode'
+            OR path LIKE '%\Users\%%\AppData\Roaming\npm\node_modules\opencode-ai\package.json'
+            OR path LIKE '%\Users\%%\AppData\Roaming\opencode\config.json'
+            OR path LIKE '%\Users\%%\AppData\Roaming\opencode\config.jsonc'
+            OR path LIKE '%\Users\%%\node_modules\opencode-ai\package.json'
+    ),
+    process_opencode AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'opencode.exe'
+            OR name = 'opencode'
+            OR cmdline LIKE '%\opencode-ai\%'
+            OR cmdline LIKE '%\node_modules\.bin\opencode %'
+    ),
+    npm_opencode AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM npm_packages
+        WHERE name = 'opencode-ai'
+            OR name = 'opencode'
+    ),
+    prefetch_opencode AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\opencode%'
+    ),
+    sockets_opencode AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\opencode%'
+    ),
+    final_score AS (
+        SELECT
+            file_opencode.total
+            + process_opencode.total
+            + npm_opencode.total
+            + prefetch_opencode.total
+            + sockets_opencode.total
+            AS score
+        FROM file_opencode, process_opencode, npm_opencode, prefetch_opencode, sockets_opencode
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS opencode_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/sourcegraph_cody_detection.yml
+++ b/sample_osquery_checks/Windows/sourcegraph_cody_detection.yml
@@ -1,0 +1,64 @@
+title: Sourcegraph Cody AI Assistant Detection
+id: b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9
+description: |
+    Detects the presence of Sourcegraph Cody, an AI coding assistant with deep code-graph
+    awareness. Cody integrates into VS Code, JetBrains, and other editors via an extension
+    (sourcegraph.cody-ai) and optionally connects to a Sourcegraph instance to provide
+    repository-wide context. Unlike assistants limited to the currently open file, Cody can
+    index and query an entire codebase graph, making it capable of transmitting large volumes
+    of proprietary code to Anthropic's Claude API or the configured provider. The cody-agent
+    background process handles the language server protocol and code indexing. This detection
+    evaluates VS Code extension directories across VS Code and Cursor, VS Code global storage,
+    and the cody-agent process. A score greater than 1 (at least two positive indicators) is
+    required to confirm detection.
+references:
+    - https://sourcegraph.com/cody
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH file_cody AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        -- VS Code and Cursor extension directories
+        WHERE path LIKE '%\Users\%%\.vscode\extensions\sourcegraph.cody-ai-%'
+            OR path LIKE '%\Users\%%\.cursor\extensions\sourcegraph.cody-ai-%'
+            -- VS Code global storage confirms active usage
+            OR path LIKE '%\Users\%%\AppData\Roaming\Code\User\globalStorage\sourcegraph.cody-ai\%'
+    ),
+    process_cody AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'cody-agent.exe'
+            OR name = 'cody-agent'
+            OR cmdline LIKE '%sourcegraph.cody-ai%'
+            OR cmdline LIKE '%cody-agent%'
+    ),
+    prefetch_cody AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\cody-agent%'
+            OR path LIKE '%sourcegraph.cody%'
+    ),
+    sockets_cody AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\cody-agent%'
+    ),
+    final_score AS (
+        SELECT
+            file_cody.total
+            + process_cody.total
+            + prefetch_cody.total
+            + sockets_cody.total
+            AS score
+        FROM file_cody, process_cody, prefetch_cody, sockets_cody
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS cody_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/supermaven_ai_completion_detection.yml
+++ b/sample_osquery_checks/Windows/supermaven_ai_completion_detection.yml
@@ -1,0 +1,67 @@
+title: Supermaven AI Code Completion Detection
+id: d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1
+description: |
+    Detects the presence of Supermaven, an AI code completion tool that claims the largest
+    context window among code completion products (300,000 tokens). Supermaven installs as a
+    VS Code extension (supermaven.supermaven) that spawns a persistent background binary
+    (supermaven-binary) responsible for communicating with Supermaven's servers. Unlike
+    extensions that only transmit the current file, Supermaven's large context window means
+    it may continuously transmit the content of many open files, recent edits, and cross-file
+    symbols to its cloud service for inference. The supermaven-binary process starts automatically
+    at VS Code launch and runs persistently. This detection evaluates VS Code extension
+    directories, the supermaven-binary process, application data directories, and prefetch
+    entries. A score greater than 1 (at least two positive indicators) is required to confirm
+    detection.
+references:
+    - https://supermaven.com
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH file_supermaven AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        -- VS Code and Cursor extension directories
+        WHERE path LIKE '%\Users\%%\.vscode\extensions\supermaven.supermaven-%'
+            OR path LIKE '%\Users\%%\.cursor\extensions\supermaven.supermaven-%'
+            -- VS Code global storage and app data
+            OR path LIKE '%\Users\%%\AppData\Roaming\Code\User\globalStorage\supermaven.supermaven\%'
+            OR path LIKE '%\Users\%%\AppData\Roaming\Supermaven\%'
+            OR path LIKE '%\Users\%%\AppData\Local\Supermaven\%'
+    ),
+    process_supermaven AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'supermaven-binary.exe'
+            OR name = 'supermaven-binary'
+            OR name LIKE '%supermaven%'
+    ),
+    prefetch_supermaven AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\supermaven-binary%'
+            OR path LIKE '%\supermaven%'
+    ),
+    sockets_supermaven AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\supermaven-binary%'
+            OR path LIKE '%\supermaven%'
+    ),
+    final_score AS (
+        SELECT
+            file_supermaven.total
+            + process_supermaven.total
+            + prefetch_supermaven.total
+            + sockets_supermaven.total
+            AS score
+        FROM file_supermaven, process_supermaven, prefetch_supermaven, sockets_supermaven
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS supermaven_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/tabnine_ai_coding_assistant_detection.yml
+++ b/sample_osquery_checks/Windows/tabnine_ai_coding_assistant_detection.yml
@@ -1,0 +1,68 @@
+title: Tabnine AI Coding Assistant Detection
+id: 7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b
+description: |
+    Detects the presence of Tabnine, an AI code-completion assistant with a large enterprise
+    install base. Tabnine integrates into VS Code, JetBrains IDEs, Vim, and other editors
+    via dedicated plugins and stores a local model cache in %USERPROFILE%\.tabninecache\ that
+    can be several gigabytes. In its cloud tier, all code completions are processed by
+    Tabnine's servers, meaning code context (including partial function implementations,
+    variable names, and comments) is transmitted externally. Tabnine Enterprise customers can
+    self-host the model, but without explicit confirmation, cloud transmission should be
+    assumed. The %USERPROFILE%\.tabnine\ directory may contain authentication tokens. Tabnine's
+    VS Code extension (tabnine.tabnine-vscode) is often silently installed as part of IDE
+    extension packs without the developer's explicit awareness, making it a common source of
+    inadvertent data exfiltration in enterprise environments. This detection evaluates the
+    local cache directory, VS Code and JetBrains extension paths, running processes, and
+    prefetch entries. A score greater than 1 (at least two positive indicators) is required
+    to confirm detection.
+references:
+    - https://www.tabnine.com
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH file_tabnine AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '%\Users\%%\.tabninecache\%'
+            OR path LIKE '%\Users\%%\.tabnine\%'
+            -- VS Code extension
+            OR path LIKE '%\Users\%%\.vscode\extensions\tabnine.tabnine-vscode-%'
+            -- JetBrains plugin
+            OR path LIKE '%\Users\%%\AppData\Roaming\JetBrains\%%\plugins\tabnine-jetbrains\%'
+    ),
+    process_tabnine AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%TabNine%'
+            OR name LIKE '%tabnine%'
+    ),
+    prefetch_tabnine AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\TabNine%'
+            OR path LIKE '%\tabnine%'
+    ),
+    sockets_tabnine AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\TabNine%'
+            OR path LIKE '%\tabnine%'
+    ),
+    final_score AS (
+        SELECT
+            file_tabnine.total
+            + process_tabnine.total
+            + prefetch_tabnine.total
+            + sockets_tabnine.total
+            AS score
+        FROM file_tabnine, process_tabnine, prefetch_tabnine, sockets_tabnine
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS tabnine_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/Windows/windsurf_codeium_detection.yml
+++ b/sample_osquery_checks/Windows/windsurf_codeium_detection.yml
@@ -32,6 +32,8 @@ query: |
             OR path LIKE '%\Users\%%\AppData\Roaming\Windsurf\User\settings.json'
             OR path LIKE '%\Users\%%\.codeium\config.json'
             OR path LIKE '%\Users\%%\.windsurf\%'
+            -- MCP configuration
+            OR path LIKE '%\Users\%%\.codeium\windsurf\mcp_config.json'
     ),
     process_windsurf AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/windsurf_codeium_detection.yml
+++ b/sample_osquery_checks/Windows/windsurf_codeium_detection.yml
@@ -1,0 +1,79 @@
+title: Windsurf (Codeium) AI Editor Detection
+id: a6b3f8d2c9e1407f5a6b3f8d2c9e1a3b
+description: |
+    Detects the presence of Windsurf, Codeium's AI-native code editor, on Windows devices.
+    Windsurf is an Electron-based IDE that embeds AI coding assistance through its Cascade agent,
+    which can autonomously read files, run terminal commands, and browse the web on the user's
+    behalf. Windsurf installs a persistent Codeium engine that runs alongside the editor and
+    stores code embeddings and interaction history locally across multiple directories
+    (AppData\Roaming\Windsurf, .codeium, .windsurf). All AI interactions transmit code context
+    to Codeium's servers. This detection evaluates startup items, file paths, running processes,
+    installed programs, and prefetch entries to identify Windsurf installations. A score greater
+    than 1 (at least two positive indicators) is required to confirm detection.
+references:
+    - https://windsurf.com
+    - https://codeium.com
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH startup_windsurf AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM startup_items
+        WHERE name LIKE '%windsurf%'
+            OR name LIKE '%codeium%'
+    ),
+    file_windsurf AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '%\Users\%%\AppData\Local\Programs\windsurf\Windsurf.exe'
+            OR path LIKE '%\Users\%%\AppData\Local\windsurf\%'
+            OR path LIKE '%\Users\%%\AppData\Roaming\Windsurf\User\settings.json'
+            OR path LIKE '%\Users\%%\.codeium\config.json'
+            OR path LIKE '%\Users\%%\.windsurf\%'
+    ),
+    process_windsurf AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%windsurf%'
+            OR name LIKE '%codeium%'
+    ),
+    programs_windsurf AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM programs
+        WHERE name LIKE '%windsurf%'
+            OR name LIKE '%codeium%'
+    ),
+    prefetch_windsurf AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\Programs\windsurf\%'
+            OR path LIKE '%\Windsurf.exe%'
+            OR path LIKE '%\codeium%'
+    ),
+    sockets_windsurf AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\windsurf%'
+            OR path LIKE '%\codeium%'
+    ),
+    final_score AS (
+        SELECT
+            startup_windsurf.total
+            + file_windsurf.total
+            + process_windsurf.total
+            + programs_windsurf.total
+            + prefetch_windsurf.total
+            + sockets_windsurf.total
+            AS score
+        FROM startup_windsurf, file_windsurf, process_windsurf, programs_windsurf,
+             prefetch_windsurf, sockets_windsurf
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS windsurf_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/aider_ai_coding_agent_detection.yml
+++ b/sample_osquery_checks/macOS/aider_ai_coding_agent_detection.yml
@@ -1,0 +1,67 @@
+title: Aider AI Coding Agent Detection
+id: 4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a
+description: |
+    Detects the presence of Aider, a Python-based autonomous AI coding agent distributed via
+    pip (aider-chat). Aider is classified as high-risk by security researchers due to its use
+    of unsandboxed shell command execution (subprocess with shell=True), unrestricted filesystem
+    access, and polling of the system clipboard every 0.5 seconds which can capture sensitive
+    data. In auto-commit mode Aider can modify files and create git commits without user
+    confirmation. All code context and conversation history is transmitted to the configured
+    LLM provider (OpenAI, Anthropic, Google, etc.). Aider stores API keys in plain text in
+    ~/.aider/ configuration files, creating a secondary credential exposure risk. Note that
+    osquery has no pip/Python package table — this detection relies on binary paths, config
+    files, and process names. A score greater than 1 (at least two positive indicators) is
+    required to confirm detection.
+references:
+    - https://aider.chat
+    - https://agent-safehouse.dev/docs/agent-investigations/aider
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH file_aider AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/usr/local/bin/aider'
+            OR path LIKE '/opt/homebrew/bin/aider'
+            OR path LIKE '/Users/%%/.local/bin/aider'
+            OR path LIKE '/Users/%%/.aider/.aider.conf.yml'
+            OR path LIKE '/Users/%%/.aider.conf.yml'
+            OR path LIKE '/Users/%%/.aider/analytics.json'
+    ),
+    process_aider AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'aider'
+            OR cmdline LIKE '%aider-chat%'
+            OR cmdline LIKE '% aider %'
+    ),
+    docker_image_aider AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%aider%'
+            OR tags LIKE '%aider-chat%'
+    ),
+    docker_container_aider AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%aider%'
+            OR image LIKE '%aider-chat%'
+    ),
+    final_score AS (
+        SELECT
+            file_aider.total
+            + process_aider.total
+            + docker_image_aider.total
+            + docker_container_aider.total
+            AS score
+        FROM file_aider, process_aider, docker_image_aider, docker_container_aider
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS aider_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/aider_ai_coding_agent_detection.yml
+++ b/sample_osquery_checks/macOS/aider_ai_coding_agent_detection.yml
@@ -29,6 +29,8 @@ query: |
             OR path LIKE '/Users/%%/.aider/.aider.conf.yml'
             OR path LIKE '/Users/%%/.aider.conf.yml'
             OR path LIKE '/Users/%%/.aider/analytics.json'
+            -- pipx installation
+            OR path LIKE '/Users/%%/.local/pipx/venvs/aider-chat/%'
     ),
     process_aider AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/anythingllm_local_server_detection.yml
+++ b/sample_osquery_checks/macOS/anythingllm_local_server_detection.yml
@@ -1,0 +1,79 @@
+title: AnythingLLM Local AI Server Detection
+id: a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2
+description: |
+    Detects the presence of AnythingLLM, a desktop application and local server that enables
+    RAG (Retrieval-Augmented Generation) workflows using locally stored documents. AnythingLLM
+    can ingest and index documents, PDFs, web pages, and other data sources, then query any
+    configured LLM (local or cloud) with that context. This makes it particularly sensitive from
+    a data exposure perspective: corporate documents uploaded into AnythingLLM workspaces may be
+    chunked, embedded, and sent to external LLM APIs depending on the provider configured.
+    AnythingLLM exposes a local web server on port 3001 by default. In server mode it can be
+    accessed over the local network and provides a multi-user API without authentication by
+    default. Storage is kept in ~/Library/Application Support/anythingllm-desktop/ including
+    the SQLite database, vector embeddings, and uploaded document contents. This detection
+    evaluates app bundle presence, application storage, running processes, and the local server
+    port. A score greater than 1 (at least two positive indicators) is required to confirm
+    detection.
+references:
+    - https://anythingllm.com
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH file_anyllm AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/Applications/AnythingLLM.app'
+            OR path LIKE '/Users/%%/Library/Application Support/anythingllm-desktop/%'
+            OR path LIKE '/Users/%%/Library/Application Support/AnythingLLM/%'
+    ),
+    process_anyllm AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%AnythingLLM%'
+            OR name LIKE '%anythingllm%'
+    ),
+    apps_anyllm AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM apps
+        WHERE name LIKE '%AnythingLLM%'
+            OR bundle_identifier LIKE '%anythingllm%'
+    ),
+    netports_anyllm AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM listening_ports
+        WHERE port = '3001'
+            AND path LIKE '%AnythingLLM%'
+    ),
+    docker_image_anyllm AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%anythingllm%'
+            OR tags LIKE '%mintplexlabs%'
+    ),
+    docker_container_anyllm AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%anythingllm%'
+            OR image LIKE '%mintplexlabs%'
+    ),
+    final_score AS (
+        SELECT
+            file_anyllm.total
+            + process_anyllm.total
+            + apps_anyllm.total
+            + netports_anyllm.total
+            + docker_image_anyllm.total
+            + docker_container_anyllm.total
+            AS score
+        FROM file_anyllm, process_anyllm, apps_anyllm, netports_anyllm,
+             docker_image_anyllm, docker_container_anyllm
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS anythingllm_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/chatgpt_desktop_detection.yml
+++ b/sample_osquery_checks/macOS/chatgpt_desktop_detection.yml
@@ -1,0 +1,75 @@
+title: ChatGPT Desktop Detection
+id: b8e274a1d5f30c6e9a2b7d4f1c8e3a5b
+description: |
+    Detects the presence of OpenAI's ChatGPT desktop application on macOS devices. The ChatGPT
+    desktop app provides native access to OpenAI models and includes features such as screen
+    capture, voice interaction, and file access that give the application broad visibility into
+    device activity. Conversations and any shared content are transmitted to OpenAI's servers and
+    retained according to OpenAI's data policies. The application also ships with a companion
+    background helper process that enables OS-level integrations. Organizations may wish to
+    restrict or monitor ChatGPT Desktop usage on corporate devices to ensure compliance with
+    data-handling policies. This detection evaluates launchd services, file paths, running
+    processes, and installed applications to identify ChatGPT Desktop installations. A score
+    greater than 1 (at least two positive indicators) is required to confirm detection.
+references:
+    - https://openai.com/chatgpt/desktop/
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH launchd_chatgpt AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM launchd
+        WHERE name LIKE '%openai%'
+            OR name LIKE '%chatgpt%'
+    ),
+    file_chatgpt AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/Applications/ChatGPT.app'
+            OR path LIKE '/Users/%%/Library/Application Support/ChatGPT/app-settings.json'
+            OR path LIKE '/Users/%%/Library/Application Support/ChatGPT/%'
+    ),
+    process_chatgpt AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%chatgpt%'
+    ),
+    apps_chatgpt AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM apps
+        WHERE name LIKE '%chatgpt%'
+            OR bundle_identifier LIKE '%openai%'
+    ),
+    docker_image_chatgpt AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%chatgpt%'
+            OR tags LIKE '%openai%'
+    ),
+    docker_container_chatgpt AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%chatgpt%'
+            OR image LIKE '%openai%'
+    ),
+    final_score AS (
+        SELECT
+            launchd_chatgpt.total
+            + file_chatgpt.total
+            + process_chatgpt.total
+            + apps_chatgpt.total
+            + docker_image_chatgpt.total
+            + docker_container_chatgpt.total
+            AS score
+        FROM launchd_chatgpt, file_chatgpt, process_chatgpt, apps_chatgpt,
+             docker_image_chatgpt, docker_container_chatgpt
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS chatgpt_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/claude_ai_assistant_detection.yml
+++ b/sample_osquery_checks/macOS/claude_ai_assistant_detection.yml
@@ -1,0 +1,97 @@
+title: Claude AI Assistant Detection
+id: a3f812b9c4e15d2f7a8b6c3d9e0f1a2b
+description: |
+    Detects the presence of Anthropic's Claude AI assistant on macOS devices, covering both the
+    Claude Desktop application and the Claude Code CLI tool. Claude Desktop provides a native
+    interface for interacting with Claude models and can access local files through MCP
+    (Model Context Protocol), enabling broad system interactions. Claude Code is an agentic
+    coding tool capable of reading and modifying files, executing shell commands, and interacting
+    with external services on the user's behalf. Both tools may transmit sensitive data including
+    code, file contents, and conversation history to Anthropic's servers. This detection evaluates
+    launchd services, file paths, running processes, Homebrew packages, npm packages, installed
+    applications, and Docker artifacts to identify Claude installations. A score greater than 1
+    (at least two positive indicators) is required to confirm detection.
+references:
+    - https://claude.ai
+    - https://www.anthropic.com
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH launchd_claude AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM launchd
+        WHERE name LIKE '%claude%'
+            OR name LIKE '%anthropic%'
+    ),
+    file_claude AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/Applications/Claude.app'
+            OR path LIKE '/Users/%%/.claude/settings.json'
+            OR path LIKE '/Users/%%/.claude/CLAUDE.md'
+            OR path LIKE '/Users/%%/.local/bin/claude'
+            OR path LIKE '/Users/%%/.volta/bin/claude'
+            OR path LIKE '/usr/local/bin/claude'
+            OR path LIKE '/opt/homebrew/bin/claude'
+            OR path LIKE '/Users/%%/node_modules/@anthropic-ai/claude-code/package.json'
+    ),
+    process_claude AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%claude%'
+            OR cmdline LIKE '%/@anthropic-ai/claude-code/%'
+            OR cmdline LIKE '%/node_modules/.bin/claude %'
+    ),
+    homebrew_claude AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM homebrew_packages
+        WHERE name LIKE '%claude%'
+            OR name LIKE '%anthropic%'
+    ),
+    npm_claude AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM npm_packages
+        WHERE name LIKE '%claude%'
+            OR name LIKE '%anthropic%'
+    ),
+    apps_claude AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM apps
+        WHERE name LIKE '%claude%'
+            OR bundle_identifier LIKE '%anthropic%'
+    ),
+    docker_image_claude AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%claude%'
+            OR tags LIKE '%anthropic%'
+    ),
+    docker_container_claude AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%claude%'
+            OR image LIKE '%anthropic%'
+    ),
+    final_score AS (
+        SELECT
+            launchd_claude.total
+            + file_claude.total
+            + process_claude.total
+            + homebrew_claude.total
+            + npm_claude.total
+            + apps_claude.total
+            + docker_image_claude.total
+            + docker_container_claude.total
+            AS score
+        FROM launchd_claude, file_claude, process_claude, homebrew_claude, npm_claude,
+             apps_claude, docker_image_claude, docker_container_claude
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS claude_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/claude_ai_assistant_detection.yml
+++ b/sample_osquery_checks/macOS/claude_ai_assistant_detection.yml
@@ -36,6 +36,8 @@ query: |
             OR path LIKE '/usr/local/bin/claude'
             OR path LIKE '/opt/homebrew/bin/claude'
             OR path LIKE '/Users/%%/node_modules/@anthropic-ai/claude-code/package.json'
+            -- MCP configuration (Claude Desktop)
+            OR path LIKE '/Users/%%/Library/Application Support/Claude/claude_desktop_config.json'
     ),
     process_claude AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/cline_roo_ai_agent_detection.yml
+++ b/sample_osquery_checks/macOS/cline_roo_ai_agent_detection.yml
@@ -1,0 +1,73 @@
+title: Cline / Roo-Cline AI Coding Agent Detection
+id: e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6
+description: |
+    Detects the presence of Cline (formerly Claude Dev) and its fork Roo-Cline, VS Code
+    extensions that enable fully autonomous agentic AI coding within the editor. Unlike
+    GitHub Copilot and other assistants that make suggestions, Cline/Roo-Cline are agent
+    runtimes: they can read and write any file, execute arbitrary shell commands, manage
+    browser sessions, and call MCP servers — all approved with a single up-front permission
+    grant. Roo-Cline adds additional modes (Architect, Ask, Code, Debug) and more aggressive
+    auto-approval defaults. Both extensions transmit the full content of open files, terminal
+    output, and shell command results to the configured LLM provider (Anthropic, OpenAI,
+    Google, or any OpenAI-compatible API). API keys are stored in VS Code's extension global
+    storage. Because these tools run inside the VS Code process, they inherit the IDE's
+    filesystem access, including any mounted network shares or credentials visible to the
+    editor. This detection covers both Cline and Roo-Cline across VS Code and Cursor extension
+    directories, as well as VS Code global storage confirming active use. Full Disk Access is
+    required for the Application Support paths. A score greater than 1 (at least two positive
+    indicators) is required to confirm detection.
+references:
+    - https://github.com/cline/cline
+    - https://github.com/RooVetGit/Roo-Code
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH file_cline AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        -- VS Code extension directories (Cline and Roo-Cline)
+        WHERE path LIKE '/Users/%%/.vscode/extensions/saoudrizwan.claude-dev-%'
+            OR path LIKE '/Users/%%/.vscode/extensions/rooveterinaryinc.roo-cline-%'
+            -- Cursor extension directories
+            OR path LIKE '/Users/%%/.cursor/extensions/saoudrizwan.claude-dev-%'
+            OR path LIKE '/Users/%%/.cursor/extensions/rooveterinaryinc.roo-cline-%'
+            -- VS Code global storage confirms active usage (requires Full Disk Access)
+            OR path LIKE '/Users/%%/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/%'
+            OR path LIKE '/Users/%%/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/%'
+    ),
+    process_cline AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE cmdline LIKE '%saoudrizwan.claude-dev%'
+            OR cmdline LIKE '%rooveterinaryinc.roo-cline%'
+    ),
+    docker_image_cline AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%cline%'
+            OR tags LIKE '%roo-cline%'
+    ),
+    docker_container_cline AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%cline%'
+            OR image LIKE '%roo-cline%'
+    ),
+    final_score AS (
+        SELECT
+            file_cline.total
+            + process_cline.total
+            + docker_image_cline.total
+            + docker_container_cline.total
+            AS score
+        FROM file_cline, process_cline, docker_image_cline, docker_container_cline
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS cline_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/continue_dev_ai_coding_assistant_detection.yml
+++ b/sample_osquery_checks/macOS/continue_dev_ai_coding_assistant_detection.yml
@@ -1,0 +1,76 @@
+title: Continue.dev AI Coding Assistant Detection
+id: 3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d
+description: |
+    Detects the presence of Continue.dev, an open-source AI coding assistant extension for VS
+    Code and JetBrains IDEs. Unlike single-provider tools such as GitHub Copilot, Continue.dev
+    acts as a universal proxy that can route editor queries to any configured LLM provider —
+    including local models (Ollama, LM Studio, Jan.ai), OpenAI, Anthropic, Google, and any
+    OpenAI-compatible API. Its MCP (Model Context Protocol) support enables deep tool
+    integrations: the extension can be configured to give the model access to the local
+    filesystem, terminal, databases, and external APIs directly from the IDE. The primary
+    configuration file (~/.continue/config.yaml or config.json) is stored in plaintext and
+    may contain API keys for multiple LLM providers. Any secrets placed here are readable by
+    any process with user-level access on the device. This detection evaluates the Continue.dev
+    configuration directory, VS Code extension installation, and the background language server
+    process launched by the extension. A score greater than 1 (at least two positive
+    indicators) is required to confirm detection.
+references:
+    - https://continue.dev
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH file_continue AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/Users/%%/.continue/config.yaml'
+            OR path LIKE '/Users/%%/.continue/config.json'
+            OR path LIKE '/Users/%%/.continue/config.ts'
+            -- VS Code extension directory
+            OR path LIKE '/Users/%%/.vscode/extensions/continue.continue-%'
+    ),
+    process_continue AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        -- Language server spawned by the VS Code extension
+        WHERE cmdline LIKE '%/continue.continue-%/out/extension%'
+            OR cmdline LIKE '%/.continue/bin/%'
+            OR name = 'continue-binary'
+    ),
+    npm_continue AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM npm_packages
+        WHERE name LIKE '%continuedev%'
+            OR name LIKE '%@continuedev%'
+    ),
+    docker_image_continue AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%continuedev%'
+            OR tags LIKE '%continue-dev%'
+    ),
+    docker_container_continue AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%continuedev%'
+            OR image LIKE '%continue-dev%'
+    ),
+    final_score AS (
+        SELECT
+            file_continue.total
+            + process_continue.total
+            + npm_continue.total
+            + docker_image_continue.total
+            + docker_container_continue.total
+            AS score
+        FROM file_continue, process_continue, npm_continue,
+             docker_image_continue, docker_container_continue
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS continue_dev_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/cursor_ai_editor_detection.yml
+++ b/sample_osquery_checks/macOS/cursor_ai_editor_detection.yml
@@ -1,0 +1,81 @@
+title: Cursor AI Editor Detection
+id: e9b3f6d2a7c1450e8f3b9d6a2c5e7f1b
+description: |
+    Detects the presence of Cursor, an AI-native code editor built on VS Code, on macOS devices.
+    Cursor embeds AI coding assistance directly into the editor and by default sends code context
+    — including open files, terminal output, and repository history — to Cursor's servers and
+    third-party AI providers (OpenAI, Anthropic, Google). The editor's Agent mode can autonomously
+    execute code, run terminal commands, and modify files without per-action confirmation. Privacy
+    mode is available but requires explicit opt-in. Organizations may wish to audit Cursor usage
+    on corporate devices to assess data exposure and enforce approved AI tooling policies. This
+    detection evaluates launchd services, file paths, running processes, Homebrew packages, and
+    installed applications to identify Cursor installations. A score greater than 1 (at least
+    two positive indicators) is required to confirm detection.
+references:
+    - https://cursor.com
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH launchd_cursor AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM launchd
+        WHERE name LIKE '%cursor%'
+    ),
+    file_cursor AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/Applications/Cursor.app'
+            OR path LIKE '/Users/%%/.cursor/mcp.json'
+            OR path LIKE '/Users/%%/.cursor/extensions/%'
+            OR path LIKE '/Users/%%/Library/Application Support/Cursor/User/settings.json'
+    ),
+    process_cursor AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%cursor%'
+            AND path NOT LIKE '/System/%'
+            AND path NOT LIKE '/Library/%'
+    ),
+    homebrew_cursor AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM homebrew_packages
+        WHERE name LIKE '%cursor%'
+    ),
+    apps_cursor AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM apps
+        WHERE (name LIKE '%cursor%' OR bundle_identifier LIKE '%cursor%')
+            AND bundle_identifier NOT LIKE 'com.apple.%'
+    ),
+    docker_image_cursor AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%cursor%'
+    ),
+    docker_container_cursor AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%cursor%'
+    ),
+    final_score AS (
+        SELECT
+            launchd_cursor.total
+            + file_cursor.total
+            + process_cursor.total
+            + homebrew_cursor.total
+            + apps_cursor.total
+            + docker_image_cursor.total
+            + docker_container_cursor.total
+            AS score
+        FROM launchd_cursor, file_cursor, process_cursor, homebrew_cursor, apps_cursor,
+             docker_image_cursor, docker_container_cursor
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS cursor_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/gemini_cli_detection.yml
+++ b/sample_osquery_checks/macOS/gemini_cli_detection.yml
@@ -1,0 +1,81 @@
+title: Gemini CLI AI Coding Agent Detection
+id: 3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f
+description: |
+    Detects the presence of Google's Gemini CLI, an agentic AI coding assistant distributed as
+    an npm package (@google/gemini-cli). Gemini CLI is the Google equivalent of Claude Code and
+    OpenAI Codex CLI — it can autonomously read and write files, execute shell commands, run
+    tests, search the web, and interact with MCP servers on the user's behalf. All interactions
+    and code context, including file contents and command outputs, are transmitted to Google's
+    Gemini API. The tool authenticates via Google OAuth, linking activity to the user's Google
+    account and potentially to Google Workspace data. Organizations with Google Workspace should
+    evaluate whether Gemini CLI usage is covered by their existing data-processing agreements
+    with Google. This detection evaluates file paths, running processes, npm packages, and
+    Homebrew installations to identify Gemini CLI presence. Local project installs are covered
+    via node_modules path matching. A score greater than 1 (at least two positive indicators)
+    is required to confirm detection.
+references:
+    - https://github.com/google-gemini/gemini-cli
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH file_gemini AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/Users/%%/.gemini/settings.json'
+            OR path LIKE '/Users/%%/.volta/bin/gemini'
+            OR path LIKE '/Users/%%/.local/bin/gemini'
+            OR path LIKE '/usr/local/bin/gemini'
+            OR path LIKE '/opt/homebrew/bin/gemini'
+            OR path LIKE '/Users/%%/node_modules/@google/gemini-cli/package.json'
+    ),
+    process_gemini AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'gemini'
+            OR cmdline LIKE '%/@google/gemini-cli/%'
+            OR cmdline LIKE '%/node_modules/.bin/gemini %'
+    ),
+    homebrew_gemini AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM homebrew_packages
+        WHERE name = 'gemini-cli'
+    ),
+    npm_gemini AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM npm_packages
+        WHERE name LIKE '%google/gemini-cli%'
+            OR name = 'gemini-cli'
+    ),
+    docker_image_gemini AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%gemini-cli%'
+            OR tags LIKE '%google/gemini%'
+    ),
+    docker_container_gemini AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%gemini-cli%'
+            OR image LIKE '%google/gemini%'
+    ),
+    final_score AS (
+        SELECT
+            file_gemini.total
+            + process_gemini.total
+            + homebrew_gemini.total
+            + npm_gemini.total
+            + docker_image_gemini.total
+            + docker_container_gemini.total
+            AS score
+        FROM file_gemini, process_gemini, homebrew_gemini, npm_gemini,
+             docker_image_gemini, docker_container_gemini
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS gemini_cli_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/github_copilot_detection.yml
+++ b/sample_osquery_checks/macOS/github_copilot_detection.yml
@@ -1,0 +1,61 @@
+title: GitHub Copilot Detection
+id: d1f4e7a2c9b5380f6d2e8b4a7c1f3d9e
+description: |
+    Detects the presence of GitHub Copilot on macOS devices, including the VS Code extension,
+    the Copilot language server, and the Copilot CLI. GitHub Copilot transmits code context
+    from the active editor — including open files, surrounding code, and repository content —
+    to GitHub's servers for AI completion. The Copilot CLI extends this capability to shell
+    commands and git operations. Organizations subject to strict data residency or IP protection
+    requirements may wish to control or audit Copilot usage on corporate devices. This detection
+    evaluates file paths (VS Code extension directory, credential and config files), running
+    processes, and npm packages to identify GitHub Copilot installations. A score greater than 1
+    (at least two positive indicators) is required to confirm detection.
+references:
+    - https://github.com/features/copilot
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH file_copilot AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/Users/%%/.vscode/extensions/github.copilot-%'
+            OR path LIKE '/Users/%%/.vscode/extensions/github.copilot-chat-%'
+            OR path LIKE '/Users/%%/.config/github-copilot/hosts.json'
+            OR path LIKE '/Users/%%/.config/github-copilot/apps.json'
+            OR path LIKE '/Users/%%/node_modules/@github/copilot-language-server/package.json'
+    ),
+    process_copilot AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%copilot%'
+            OR cmdline LIKE '%/copilot-language-server%'
+            OR cmdline LIKE '%/@github/copilot%'
+    ),
+    npm_copilot AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM npm_packages
+        WHERE name LIKE '%copilot%'
+    ),
+    homebrew_copilot AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM homebrew_packages
+        WHERE name LIKE '%copilot%'
+    ),
+    final_score AS (
+        SELECT
+            file_copilot.total
+            + process_copilot.total
+            + npm_copilot.total
+            + homebrew_copilot.total
+            AS score
+        FROM file_copilot, process_copilot, npm_copilot, homebrew_copilot
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS copilot_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/goose_ai_agent_detection.yml
+++ b/sample_osquery_checks/macOS/goose_ai_agent_detection.yml
@@ -1,0 +1,68 @@
+title: Goose AI Agent Detection (Block)
+id: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6
+description: |
+    Detects the presence of Goose, an open-source autonomous AI software engineering agent
+    developed by Block (formerly Square). Goose is a command-line agent that can read and write
+    files, execute shell commands, browse the web, interact with APIs, and chain together complex
+    multi-step tasks on the user's behalf. Unlike tools limited to code completion, Goose is
+    designed for end-to-end task automation: it can manage git repositories, run test suites,
+    modify build pipelines, and call external services — all without per-action confirmation in
+    default configuration. Goose supports MCP (Model Context Protocol) extensions and can be
+    configured to use any LLM provider including local models via Ollama, significantly expanding
+    the tools it can call and the data it can access. Configuration profiles are stored in plain
+    text at ~/.config/goose/profiles.yaml and may contain API keys. Session transcripts are
+    written to ~/.local/share/goose/sessions/ and can contain sensitive code context. This
+    detection evaluates binary paths, config files, session data, and running processes. A score
+    greater than 1 (at least two positive indicators) is required to confirm detection.
+references:
+    - https://block.github.io/goose
+    - https://github.com/block/goose
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH file_goose AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/Users/%%/.local/bin/goose'
+            OR path LIKE '/opt/homebrew/bin/goose'
+            OR path LIKE '/usr/local/bin/goose'
+            OR path LIKE '/Users/%%/.config/goose/profiles.yaml'
+            OR path LIKE '/Users/%%/.config/goose/config.yaml'
+            OR path LIKE '/Users/%%/.local/share/goose/sessions/%'
+    ),
+    process_goose AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'goose'
+            OR cmdline LIKE '%block-goose%'
+    ),
+    docker_image_goose AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%block/goose%'
+            OR tags LIKE '%block-goose%'
+    ),
+    docker_container_goose AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%block/goose%'
+            OR image LIKE '%block-goose%'
+    ),
+    final_score AS (
+        SELECT
+            file_goose.total
+            + process_goose.total
+            + docker_image_goose.total
+            + docker_container_goose.total
+            AS score
+        FROM file_goose, process_goose, docker_image_goose, docker_container_goose
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS goose_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/gpt4all_local_llm_detection.yml
+++ b/sample_osquery_checks/macOS/gpt4all_local_llm_detection.yml
@@ -1,0 +1,80 @@
+title: GPT4All Local LLM Detection
+id: e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0
+description: |
+    Detects the presence of GPT4All, a desktop application for running open-source language models
+    locally, developed by Nomic AI. GPT4All downloads and stores model weight files on the device
+    (typically in ~/Library/Application Support/nomic.ai/GPT4All/) and provides both a graphical
+    interface and an optional local API server on port 4891. The API server is OpenAI-compatible
+    and, when enabled, allows any local process to query the model without authentication. As with
+    other local LLM solutions, inference happens entirely on-device, making cloud-based DLP
+    controls blind to data sent through GPT4All. The application can also connect to external
+    Nomic Atlas services for document embedding and retrieval, creating an additional data
+    transmission channel. Organizations should assess whether GPT4All constitutes an approved
+    local inference solution and whether the local API server (if enabled) poses a lateral
+    movement risk. This detection evaluates app bundle presence, model storage directories,
+    running processes, and the local API port. A score greater than 1 (at least two positive
+    indicators) is required to confirm detection.
+references:
+    - https://gpt4all.io
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH file_gpt4all AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/Applications/GPT4All.app'
+            OR path LIKE '/Users/%%/Library/Application Support/nomic.ai/GPT4All/%'
+            OR path LIKE '/Users/%%/Library/Application Support/GPT4All/%'
+    ),
+    process_gpt4all AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%GPT4All%'
+            OR name LIKE '%gpt4all%'
+    ),
+    apps_gpt4all AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM apps
+        WHERE name LIKE '%GPT4All%'
+            OR bundle_identifier LIKE '%gpt4all%'
+            OR bundle_identifier LIKE '%nomic%'
+    ),
+    netports_gpt4all AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM listening_ports
+        WHERE port = '4891'
+            AND path LIKE '%GPT4All%'
+    ),
+    docker_image_gpt4all AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%gpt4all%'
+            OR tags LIKE '%nomic-ai%'
+    ),
+    docker_container_gpt4all AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%gpt4all%'
+            OR image LIKE '%nomic-ai%'
+    ),
+    final_score AS (
+        SELECT
+            file_gpt4all.total
+            + process_gpt4all.total
+            + apps_gpt4all.total
+            + netports_gpt4all.total
+            + docker_image_gpt4all.total
+            + docker_container_gpt4all.total
+            AS score
+        FROM file_gpt4all, process_gpt4all, apps_gpt4all, netports_gpt4all,
+             docker_image_gpt4all, docker_container_gpt4all
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS gpt4all_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/jan_ai_local_llm_detection.yml
+++ b/sample_osquery_checks/macOS/jan_ai_local_llm_detection.yml
@@ -1,0 +1,79 @@
+title: Jan.ai Local LLM Detection
+id: 1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b
+description: |
+    Detects the presence of Jan.ai, an open-source desktop application for running large
+    language models entirely on-device. Jan.ai downloads and stores model weight files in
+    ~/.jan/models/ and provides an OpenAI-compatible API server on port 1337 (the "Jan API
+    Server"). The local server can be accessed by any application on the device or, if the
+    user changes the bind address, from the local network. As with other local LLM servers
+    (Ollama, LM Studio), all inference happens locally so outbound DLP controls have no
+    visibility into data processed by Jan.ai. Jan.ai additionally supports MCP (Model Context
+    Protocol) tool integrations that can grant local AI models access to the filesystem,
+    shell, and other device resources. Organizations should classify Jan.ai under the same
+    risk category as Ollama and LM Studio. This detection evaluates file paths, running
+    processes, installed applications, and the local API port. A score greater than 1
+    (at least two positive indicators) is required to confirm detection.
+references:
+    - https://jan.ai
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH file_jan AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/Applications/Jan.app'
+            OR path LIKE '/Users/%%/.jan/models/%'
+            OR path LIKE '/Users/%%/.jan/settings.json'
+            OR path LIKE '/Users/%%/.jan/extensions/%'
+    ),
+    process_jan AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'Jan'
+            OR name LIKE '%jan-ai%'
+    ),
+    apps_jan AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM apps
+        WHERE name LIKE '%Jan%'
+            AND (bundle_identifier LIKE '%jan%' OR bundle_identifier LIKE '%jan-ai%')
+    ),
+    netports_jan AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM listening_ports
+        WHERE port = '1337'
+            AND path LIKE '%Jan%'
+    ),
+    docker_image_jan AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%jan-ai%'
+            OR tags LIKE '%menlo-park-ai%'
+    ),
+    docker_container_jan AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%jan-ai%'
+            OR image LIKE '%menlo-park-ai%'
+    ),
+    final_score AS (
+        SELECT
+            file_jan.total
+            + process_jan.total
+            + apps_jan.total
+            + netports_jan.total
+            + docker_image_jan.total
+            + docker_container_jan.total
+            AS score
+        FROM file_jan, process_jan, apps_jan, netports_jan,
+             docker_image_jan, docker_container_jan
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS jan_ai_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/kiro_amazon_q_detection.yml
+++ b/sample_osquery_checks/macOS/kiro_amazon_q_detection.yml
@@ -33,6 +33,8 @@ query: |
             OR path LIKE '/Users/%%/.amazonq/scopes/scope.json'
             -- AWS Toolkit VS Code extension (ships Kiro/Q integration)
             OR path LIKE '/Users/%%/.vscode/extensions/amazonwebservices.aws-toolkit-vscode-%'
+            -- Legacy Amazon Q CLI binary (named q)
+            OR path LIKE '/Users/%%/.local/bin/q'
     ),
     process_kiro AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/kiro_amazon_q_detection.yml
+++ b/sample_osquery_checks/macOS/kiro_amazon_q_detection.yml
@@ -1,0 +1,79 @@
+title: Kiro (Amazon Q) AI Developer Tool Detection
+id: 2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e
+description: |
+    Detects the presence of Kiro, AWS's AI-powered developer tool and successor to Amazon Q
+    Developer CLI. Kiro is an agentic coding assistant with deep AWS integration that can read
+    and modify files, execute shell commands, run tests, and interact directly with AWS services
+    and credentials available on the device. Its MCP (Model Context Protocol) support enables
+    broad tool integrations including access to databases, APIs, and cloud infrastructure.
+    Because Kiro authenticates through AWS IAM Identity Center, a compromised or misconfigured
+    Kiro session may have the same AWS permissions as the authenticated user, including access
+    to production secrets. This detection also covers residual Amazon Q Developer artifacts
+    (config stored in ~/.amazonq/) that persist during the Q-to-Kiro migration. Detection
+    evaluates file paths, running processes, installed applications, and the AWS Toolkit VS Code
+    extension directory. A score greater than 1 (at least two positive indicators) is required
+    to confirm detection.
+references:
+    - https://kiro.dev
+    - https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/upgrade-to-kiro.html
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH file_kiro AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/Applications/Kiro.app'
+            OR path LIKE '/Users/%%/.kiro/settings/cli.json'
+            OR path LIKE '/Users/%%/.kiro/settings/mcp.json'
+            OR path LIKE '/Users/%%/.local/bin/kiro-cli'
+            OR path LIKE '/Users/%%/.local/bin/kiro'
+            -- Legacy Amazon Q Developer paths (pre-migration)
+            OR path LIKE '/Users/%%/.amazonq/scopes/scope.json'
+            -- AWS Toolkit VS Code extension (ships Kiro/Q integration)
+            OR path LIKE '/Users/%%/.vscode/extensions/amazonwebservices.aws-toolkit-vscode-%'
+    ),
+    process_kiro AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%kiro%'
+            OR name LIKE '%amazon-q%'
+            OR cmdline LIKE '%kiro-cli%'
+    ),
+    apps_kiro AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM apps
+        WHERE name LIKE '%kiro%'
+            OR bundle_identifier LIKE '%kiro%'
+            OR bundle_identifier LIKE '%amazonq%'
+    ),
+    docker_image_kiro AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%kiro%'
+            OR tags LIKE '%amazon-q%'
+    ),
+    docker_container_kiro AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%kiro%'
+            OR image LIKE '%amazon-q%'
+    ),
+    final_score AS (
+        SELECT
+            file_kiro.total
+            + process_kiro.total
+            + apps_kiro.total
+            + docker_image_kiro.total
+            + docker_container_kiro.total
+            AS score
+        FROM file_kiro, process_kiro, apps_kiro, docker_image_kiro, docker_container_kiro
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS kiro_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/llamacpp_inference_server_detection.yml
+++ b/sample_osquery_checks/macOS/llamacpp_inference_server_detection.yml
@@ -1,0 +1,83 @@
+title: llama.cpp Inference Server Detection
+id: c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4
+description: |
+    Detects the presence of llama.cpp, a C++ runtime for running quantized LLM models locally.
+    llama.cpp is the foundational inference engine underlying many local AI tools (Ollama uses
+    it internally) and provides llama-server, a standalone HTTP server exposing an OpenAI-
+    compatible API on port 8080. When llama-server is running, any process on the device or
+    local network can submit completions requests, process arbitrary text through the loaded
+    model, and retrieve model configuration — with no authentication by default. llama.cpp is
+    typically installed via Homebrew on macOS and is often present on developer machines
+    alongside other local LLM tools. Unlike desktop apps, llama.cpp leaves minimal GUI artifacts
+    and may run headlessly as a background server. Model files (GGUF format) can be loaded from
+    arbitrary paths. This detection evaluates binary paths, Homebrew package presence, and
+    running processes. A score greater than 1 (at least two positive indicators) is required to
+    confirm detection.
+references:
+    - https://github.com/ggml-org/llama.cpp
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH file_llamacpp AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/opt/homebrew/bin/llama-server'
+            OR path LIKE '/opt/homebrew/bin/llama-cli'
+            OR path LIKE '/opt/homebrew/bin/llama-run'
+            OR path LIKE '/usr/local/bin/llama-server'
+            OR path LIKE '/usr/local/bin/llama-cli'
+            OR path LIKE '/Users/%%/.local/bin/llama-server'
+    ),
+    process_llamacpp AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'llama-server'
+            OR name = 'llama-cli'
+            OR name = 'llama-run'
+    ),
+    homebrew_llamacpp AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM homebrew_packages
+        WHERE name = 'llama.cpp'
+    ),
+    netports_llamacpp AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM listening_ports
+        WHERE port = '8080'
+            AND path LIKE '%llama%'
+    ),
+    docker_image_llamacpp AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%llama.cpp%'
+            OR tags LIKE '%llamacpp%'
+            OR tags LIKE '%ghcr.io/ggml-org%'
+    ),
+    docker_container_llamacpp AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%llama.cpp%'
+            OR image LIKE '%llamacpp%'
+            OR image LIKE '%ggml-org%'
+    ),
+    final_score AS (
+        SELECT
+            file_llamacpp.total
+            + process_llamacpp.total
+            + homebrew_llamacpp.total
+            + netports_llamacpp.total
+            + docker_image_llamacpp.total
+            + docker_container_llamacpp.total
+            AS score
+        FROM file_llamacpp, process_llamacpp, homebrew_llamacpp, netports_llamacpp,
+             docker_image_llamacpp, docker_container_llamacpp
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS llamacpp_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/lm_studio_local_llm_detection.yml
+++ b/sample_osquery_checks/macOS/lm_studio_local_llm_detection.yml
@@ -1,0 +1,85 @@
+title: LM Studio Local LLM Detection
+id: 9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f
+description: |
+    Detects the presence of LM Studio, a desktop application for running open-source language
+    models locally. Like Ollama, LM Studio downloads and stores large model weight files on
+    the device (typically in ~/.lmstudio/models/ or ~/.cache/lm-studio/) and exposes an
+    OpenAI-compatible REST API on port 1234. Any application or user on the same machine —
+    or the local network if bound to 0.0.0.0 — can query the local model without authentication.
+    Because inference happens locally, cloud-based DLP controls that inspect outbound API
+    traffic will not detect data sent through LM Studio. Model weight files can be several
+    gigabytes and represent a significant storage and data-exfiltration surface. Organizations
+    should assess whether local LLM serving is an approved activity before allowing LM Studio
+    to be installed. This detection evaluates file paths, running processes, installed
+    applications, Homebrew installations, and the local API port. A score greater than 1
+    (at least two positive indicators) is required to confirm detection.
+references:
+    - https://lmstudio.ai
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH file_lmstudio AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/Applications/LM Studio.app'
+            OR path LIKE '/Users/%%/.lmstudio/models/%'
+            OR path LIKE '/Users/%%/.cache/lm-studio/%'
+            OR path LIKE '/Users/%%/.lmstudio/config.json'
+    ),
+    process_lmstudio AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%LM Studio%'
+            OR name LIKE '%lmstudio%'
+    ),
+    homebrew_lmstudio AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM homebrew_packages
+        WHERE name = 'lm-studio'
+    ),
+    apps_lmstudio AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM apps
+        WHERE name LIKE '%LM Studio%'
+            OR bundle_identifier LIKE '%lmstudio%'
+    ),
+    netports_lmstudio AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM listening_ports
+        WHERE port = '1234'
+            AND path LIKE '%LM Studio%'
+    ),
+    docker_image_lmstudio AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%lmstudio%'
+            OR tags LIKE '%lm-studio%'
+    ),
+    docker_container_lmstudio AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%lmstudio%'
+            OR image LIKE '%lm-studio%'
+    ),
+    final_score AS (
+        SELECT
+            file_lmstudio.total
+            + process_lmstudio.total
+            + homebrew_lmstudio.total
+            + apps_lmstudio.total
+            + netports_lmstudio.total
+            + docker_image_lmstudio.total
+            + docker_container_lmstudio.total
+            AS score
+        FROM file_lmstudio, process_lmstudio, homebrew_lmstudio, apps_lmstudio,
+             netports_lmstudio, docker_image_lmstudio, docker_container_lmstudio
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS lmstudio_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/ollama_local_llm_server_detection.yml
+++ b/sample_osquery_checks/macOS/ollama_local_llm_server_detection.yml
@@ -1,0 +1,90 @@
+title: Ollama Local LLM Server Detection
+id: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+description: |
+    Detects the presence of Ollama, a local LLM server that runs open-source language models
+    (Llama, Mistral, Gemma, etc.) directly on the device. Ollama exposes a REST API on port
+    11434 that by default binds to 0.0.0.0, making it accessible to any machine on the local
+    network without authentication. Any process or network peer can query the model, retrieve
+    loaded model weights, and use the API to process arbitrary text — including sensitive
+    corporate data. Because inference happens locally, outbound data-loss-prevention controls
+    that inspect cloud API traffic will not detect data sent through Ollama. The launchd service
+    (com.ollama) keeps the server running in the background at all times. Organizations should
+    assess whether local LLM serving is an approved activity and ensure the OLLAMA_HOST
+    environment variable is restricted to 127.0.0.1 on shared or networked devices. This
+    detection evaluates launchd services, file paths, running processes, Homebrew packages,
+    installed applications, listening ports, and Docker artifacts. A score greater than 1
+    (at least two positive indicators) is required to confirm detection.
+references:
+    - https://ollama.com
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH launchd_ollama AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM launchd
+        WHERE name LIKE '%ollama%'
+    ),
+    file_ollama AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/Applications/Ollama.app'
+            OR path LIKE '/Users/%%/.ollama/models/%'
+            OR path LIKE '/Users/%%/.ollama/config'
+            OR path LIKE '/usr/local/bin/ollama'
+            OR path LIKE '/opt/homebrew/bin/ollama'
+    ),
+    process_ollama AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%ollama%'
+    ),
+    homebrew_ollama AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM homebrew_packages
+        WHERE name = 'ollama'
+    ),
+    apps_ollama AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM apps
+        WHERE name LIKE '%ollama%'
+            OR bundle_identifier LIKE '%ollama%'
+    ),
+    netports_ollama AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM listening_ports
+        WHERE port = '11434'
+            OR path LIKE '%ollama%'
+    ),
+    docker_image_ollama AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%ollama%'
+    ),
+    docker_container_ollama AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%ollama%'
+    ),
+    final_score AS (
+        SELECT
+            launchd_ollama.total
+            + file_ollama.total
+            + process_ollama.total
+            + homebrew_ollama.total
+            + apps_ollama.total
+            + netports_ollama.total
+            + docker_image_ollama.total
+            + docker_container_ollama.total
+            AS score
+        FROM launchd_ollama, file_ollama, process_ollama, homebrew_ollama, apps_ollama,
+             netports_ollama, docker_image_ollama, docker_container_ollama
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS ollama_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/openai_codex_cli_detection.yml
+++ b/sample_osquery_checks/macOS/openai_codex_cli_detection.yml
@@ -1,0 +1,69 @@
+title: OpenAI Codex CLI Detection
+id: c5d923e8b1f47a6d0e3c9f2b8a5d7e1c
+description: |
+    Detects the presence of the OpenAI Codex CLI tool on macOS devices. Codex is an interactive
+    agentic coding assistant distributed as an npm package (@openai/codex) that can autonomously
+    read and write files, execute shell commands, and interact with external services on the
+    user's behalf. When running in auto-approval mode the tool requires no user confirmation
+    before taking actions, which can include modifying source code, running tests, and making
+    network requests. All interactions and code context are transmitted to OpenAI's API. This
+    detection evaluates file paths, running processes, and npm package installations to identify
+    Codex CLI installations. A score greater than 1 (at least two positive indicators) is
+    required to confirm detection.
+references:
+    - https://github.com/openai/codex
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH file_codex AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/Users/%%/.codex/config.json'
+            OR path LIKE '/Users/%%/.volta/bin/codex'
+            OR path LIKE '/Users/%%/.local/bin/codex'
+            OR path LIKE '/usr/local/bin/codex'
+            OR path LIKE '/opt/homebrew/bin/codex'
+            OR path LIKE '/Users/%%/node_modules/@openai/codex/package.json'
+    ),
+    process_codex AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'codex'
+            OR cmdline LIKE '%/@openai/codex/%'
+            OR cmdline LIKE '%/node_modules/.bin/codex %'
+    ),
+    npm_codex AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM npm_packages
+        WHERE name LIKE '%openai/codex%'
+            OR name = 'codex'
+    ),
+    docker_image_codex AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%openai/codex%'
+    ),
+    docker_container_codex AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%openai/codex%'
+    ),
+    final_score AS (
+        SELECT
+            file_codex.total
+            + process_codex.total
+            + npm_codex.total
+            + docker_image_codex.total
+            + docker_container_codex.total
+            AS score
+        FROM file_codex, process_codex, npm_codex, docker_image_codex, docker_container_codex
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS codex_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/openclaw_personal_ai_assistant_detection.yml
+++ b/sample_osquery_checks/macOS/openclaw_personal_ai_assistant_detection.yml
@@ -68,9 +68,10 @@ query: |
         WHERE image LIKE '%openclaw%'
         ),
     final_score AS (
-        SELECT 
-            + file_claw.total 
-            + claw_process.total 
+        SELECT
+            + launch_claw.total
+            + file_claw.total
+            + claw_process.total
             + homebrew_claw.total 
             + npm_claw.total 
             + netports_claw.total 

--- a/sample_osquery_checks/macOS/opencode_ai_agent_detection.yml
+++ b/sample_osquery_checks/macOS/opencode_ai_agent_detection.yml
@@ -1,0 +1,74 @@
+title: OpenCode AI Coding Agent Detection
+id: c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8
+description: |
+    Detects the presence of OpenCode, an open-source terminal-based AI coding agent distributed
+    as an npm package (opencode-ai). OpenCode is a CLI-first agentic tool similar to Claude Code
+    and Gemini CLI — it can autonomously read and write files, execute shell commands, run tests,
+    and interact with MCP servers on the user's behalf. All code context and conversation history
+    is transmitted to the configured LLM provider (OpenAI, Anthropic, AWS Bedrock, or others).
+    OpenCode stores its configuration in ~/.config/opencode/ and supports project-level agent
+    instruction files (AGENTS.md). This detection evaluates binary paths, npm package presence,
+    config files, and running processes. Local project npm installs are covered via node_modules
+    path matching. A score greater than 1 (at least two positive indicators) is required to
+    confirm detection.
+references:
+    - https://opencode.ai
+    - https://github.com/sst/opencode
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH file_opencode AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/Users/%%/.local/bin/opencode'
+            OR path LIKE '/opt/homebrew/bin/opencode'
+            OR path LIKE '/usr/local/bin/opencode'
+            OR path LIKE '/Users/%%/.config/opencode/config.json'
+            OR path LIKE '/Users/%%/.config/opencode/config.jsonc'
+            OR path LIKE '/Users/%%/node_modules/opencode-ai/package.json'
+    ),
+    process_opencode AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'opencode'
+            OR cmdline LIKE '%/opencode-ai/%'
+            OR cmdline LIKE '%/node_modules/.bin/opencode %'
+    ),
+    npm_opencode AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM npm_packages
+        WHERE name = 'opencode-ai'
+            OR name = 'opencode'
+    ),
+    docker_image_opencode AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%opencode-ai%'
+            OR tags LIKE '%sst/opencode%'
+    ),
+    docker_container_opencode AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%opencode-ai%'
+            OR image LIKE '%sst/opencode%'
+    ),
+    final_score AS (
+        SELECT
+            file_opencode.total
+            + process_opencode.total
+            + npm_opencode.total
+            + docker_image_opencode.total
+            + docker_container_opencode.total
+            AS score
+        FROM file_opencode, process_opencode, npm_opencode,
+             docker_image_opencode, docker_container_opencode
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS opencode_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/sourcegraph_cody_detection.yml
+++ b/sample_osquery_checks/macOS/sourcegraph_cody_detection.yml
@@ -1,0 +1,66 @@
+title: Sourcegraph Cody AI Assistant Detection
+id: a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8
+description: |
+    Detects the presence of Sourcegraph Cody, an AI coding assistant with deep code-graph
+    awareness. Cody integrates into VS Code, JetBrains, and other editors via an extension
+    (sourcegraph.cody-ai) and optionally connects to a Sourcegraph instance to provide
+    repository-wide context. Unlike assistants limited to the currently open file, Cody can
+    index and query an entire codebase graph, making it capable of transmitting large volumes
+    of proprietary code to Anthropic's Claude API or the configured provider. In enterprise
+    deployments Cody connects to a self-hosted Sourcegraph instance; in personal use it
+    connects to sourcegraph.com. Both modes require authentication tokens stored in VS Code's
+    extension global storage. The cody-agent background process (node-based) handles the
+    language server protocol and code indexing. This detection evaluates VS Code extension
+    directories across VS Code and Cursor, VS Code global storage, and the cody-agent process
+    name. Full Disk Access is required for the Application Support path. A score greater than
+    1 (at least two positive indicators) is required to confirm detection.
+references:
+    - https://sourcegraph.com/cody
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH file_cody AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        -- VS Code and Cursor extension directories
+        WHERE path LIKE '/Users/%%/.vscode/extensions/sourcegraph.cody-ai-%'
+            OR path LIKE '/Users/%%/.cursor/extensions/sourcegraph.cody-ai-%'
+            -- VS Code global storage confirms active usage (requires Full Disk Access)
+            OR path LIKE '/Users/%%/Library/Application Support/Code/User/globalStorage/sourcegraph.cody-ai/%'
+    ),
+    process_cody AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'cody-agent'
+            OR cmdline LIKE '%sourcegraph.cody-ai%'
+            OR cmdline LIKE '%cody-agent%'
+    ),
+    docker_image_cody AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%sourcegraph/cody%'
+            OR tags LIKE '%sourcegraph%'
+    ),
+    docker_container_cody AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%sourcegraph/cody%'
+    ),
+    final_score AS (
+        SELECT
+            file_cody.total
+            + process_cody.total
+            + docker_image_cody.total
+            + docker_container_cody.total
+            AS score
+        FROM file_cody, process_cody, docker_image_cody, docker_container_cody
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS cody_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/supermaven_ai_completion_detection.yml
+++ b/sample_osquery_checks/macOS/supermaven_ai_completion_detection.yml
@@ -1,0 +1,64 @@
+title: Supermaven AI Code Completion Detection
+id: c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0
+description: |
+    Detects the presence of Supermaven, an AI code completion tool that claims the largest
+    context window among code completion products (300,000 tokens). Supermaven installs as a
+    VS Code extension (supermaven.supermaven) that spawns a persistent background binary
+    (supermaven-binary) responsible for communicating with Supermaven's servers. Unlike
+    extensions that only transmit the current file, Supermaven's large context window means
+    it may continuously transmit the content of many open files, recent edits, and cross-file
+    symbols to its cloud service for inference. The supermaven-binary process starts automatically
+    at VS Code launch and runs persistently. Authentication tokens are stored in VS Code's
+    extension global storage. This detection evaluates VS Code extension directories across
+    VS Code and Cursor, the supermaven-binary process, and application support directories.
+    Full Disk Access is required for the Application Support path. A score greater than 1
+    (at least two positive indicators) is required to confirm detection.
+references:
+    - https://supermaven.com
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH file_supermaven AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        -- VS Code and Cursor extension directories
+        WHERE path LIKE '/Users/%%/.vscode/extensions/supermaven.supermaven-%'
+            OR path LIKE '/Users/%%/.cursor/extensions/supermaven.supermaven-%'
+            -- VS Code global storage and app support (requires Full Disk Access)
+            OR path LIKE '/Users/%%/Library/Application Support/Code/User/globalStorage/supermaven.supermaven/%'
+            OR path LIKE '/Users/%%/Library/Application Support/Supermaven/%'
+    ),
+    process_supermaven AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'supermaven-binary'
+            OR name LIKE '%supermaven%'
+    ),
+    docker_image_supermaven AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%supermaven%'
+    ),
+    docker_container_supermaven AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%supermaven%'
+    ),
+    final_score AS (
+        SELECT
+            file_supermaven.total
+            + process_supermaven.total
+            + docker_image_supermaven.total
+            + docker_container_supermaven.total
+            AS score
+        FROM file_supermaven, process_supermaven, docker_image_supermaven, docker_container_supermaven
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS supermaven_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/tabnine_ai_coding_assistant_detection.yml
+++ b/sample_osquery_checks/macOS/tabnine_ai_coding_assistant_detection.yml
@@ -1,0 +1,65 @@
+title: Tabnine AI Coding Assistant Detection
+id: 6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a
+description: |
+    Detects the presence of Tabnine, an AI code-completion assistant with a large enterprise
+    install base. Tabnine integrates into VS Code, JetBrains IDEs, Vim, and other editors
+    via dedicated plugins and stores a local model cache in ~/.tabninecache/ that can be
+    several gigabytes. In its cloud tier, all code completions are processed by Tabnine's
+    servers, meaning code context (including partial function implementations, variable names,
+    and comments) is transmitted externally. Tabnine Enterprise customers can self-host the
+    model, but without explicit confirmation, cloud transmission should be assumed. The
+    ~/.tabnine/ directory may contain authentication tokens. Tabnine's VS Code extension
+    (tabnine.tabnine-vscode) is often silently installed as part of IDE extension packs
+    without the developer's explicit awareness, making it a common source of inadvertent
+    data exfiltration in enterprise environments. This detection evaluates the local cache
+    directory, VS Code and JetBrains extension paths, and running processes. A score greater
+    than 1 (at least two positive indicators) is required to confirm detection.
+references:
+    - https://www.tabnine.com
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH file_tabnine AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/Users/%%/.tabninecache/%'
+            OR path LIKE '/Users/%%/.tabnine/%'
+            -- VS Code extension
+            OR path LIKE '/Users/%%/.vscode/extensions/tabnine.tabnine-vscode-%'
+            -- JetBrains plugin
+            OR path LIKE '/Users/%%/Library/Application Support/JetBrains/%%/plugins/tabnine-jetbrains/%'
+    ),
+    process_tabnine AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%TabNine%'
+            OR name LIKE '%tabnine%'
+    ),
+    docker_image_tabnine AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%tabnine%'
+    ),
+    docker_container_tabnine AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%tabnine%'
+    ),
+    final_score AS (
+        SELECT
+            file_tabnine.total
+            + process_tabnine.total
+            + docker_image_tabnine.total
+            + docker_container_tabnine.total
+            AS score
+        FROM file_tabnine, process_tabnine, docker_image_tabnine, docker_container_tabnine
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS tabnine_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/windsurf_codeium_detection.yml
+++ b/sample_osquery_checks/macOS/windsurf_codeium_detection.yml
@@ -1,0 +1,81 @@
+title: Windsurf (Codeium) AI Editor Detection
+id: f7a2c8e1d4b9630f5c2a8e3b6d1f9a7c
+description: |
+    Detects the presence of Windsurf, Codeium's AI-native code editor, on macOS devices. Windsurf
+    is an Electron-based IDE that embeds AI coding assistance through its Cascade agent, which can
+    autonomously read files, run terminal commands, and browse the web on the user's behalf.
+    Windsurf installs a persistent Codeium engine (~/.codeium) that runs alongside the editor and
+    stores code embeddings and interaction history locally. All AI interactions transmit code
+    context to Codeium's servers. The editor leaves a substantial footprint across multiple
+    directories (~/.codeium, ~/.windsurf, ~/Library/Application Support/Windsurf) totaling
+    approximately 1.75 GB. This detection evaluates file paths, running processes, and installed
+    applications to identify Windsurf installations. A score greater than 1 (at least two positive
+    indicators) is required to confirm detection.
+references:
+    - https://windsurf.com
+    - https://codeium.com
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH launchd_windsurf AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM launchd
+        WHERE name LIKE '%windsurf%'
+            OR name LIKE '%codeium%'
+    ),
+    file_windsurf AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/Applications/Windsurf.app'
+            OR path LIKE '/Users/%%/.codeium/config.json'
+            OR path LIKE '/Users/%%/.codeium/settings/%'
+            OR path LIKE '/Users/%%/.windsurf/%'
+            OR path LIKE '/Users/%%/Library/Application Support/Windsurf/User/settings.json'
+    ),
+    process_windsurf AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name LIKE '%windsurf%'
+            OR name LIKE '%codeium%'
+    ),
+    apps_windsurf AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM apps
+        WHERE name LIKE '%windsurf%'
+            OR name LIKE '%codeium%'
+            OR bundle_identifier LIKE '%windsurf%'
+            OR bundle_identifier LIKE '%codeium%'
+    ),
+    docker_image_windsurf AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%windsurf%'
+            OR tags LIKE '%codeium%'
+    ),
+    docker_container_windsurf AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%windsurf%'
+            OR image LIKE '%codeium%'
+    ),
+    final_score AS (
+        SELECT
+            launchd_windsurf.total
+            + file_windsurf.total
+            + process_windsurf.total
+            + apps_windsurf.total
+            + docker_image_windsurf.total
+            + docker_container_windsurf.total
+            AS score
+        FROM launchd_windsurf, file_windsurf, process_windsurf, apps_windsurf,
+             docker_image_windsurf, docker_container_windsurf
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS windsurf_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/windsurf_codeium_detection.yml
+++ b/sample_osquery_checks/macOS/windsurf_codeium_detection.yml
@@ -33,6 +33,8 @@ query: |
             OR path LIKE '/Users/%%/.codeium/settings/%'
             OR path LIKE '/Users/%%/.windsurf/%'
             OR path LIKE '/Users/%%/Library/Application Support/Windsurf/User/settings.json'
+            -- MCP configuration
+            OR path LIKE '/Users/%%/.codeium/windsurf/mcp_config.json'
     ),
     process_windsurf AS (
         SELECT COALESCE(COUNT(*), 0) AS total


### PR DESCRIPTION
Adds 45 new osquery-based [Advanced Posture Check](https://support.okta.com/help/s/blog/a67KZ000000oLyAYAU/introducing-advanced-posture-checks-for-device-compliance-enforcement) detections covering AI coding assistants, local LLM servers, and agentic developer tools across macOS and Windows. Also updates the existing OpenClaw detection with an additional reference, and backfills new artifact paths in several existing detections based on research from the agentic-detector community project.

---

## Detection approach

Each detection follows the same pattern established in `openclaw_personal_ai_assistant_detection.yml`:

- **Multiple independent CTEs** — each queries a different signal source (file paths, running processes, package managers, installed apps, listening ports, Docker artifacts)
- **COALESCE(COUNT(*), 0)** — ensures each CTE always returns a row even when the table is empty or the tool is absent
- **Score-based threshold** — signals are summed into a `final_score`; the device is flagged (`= 1`) only when **score > 1** (at least two independent indicators match), reducing false positives from coincidental name collisions
- **No broad cmdline matching** — process CTEs match on `name` or specific binary path patterns (e.g. `cmdline LIKE '%/@anthropic-ai/claude-code/%'`) to prevent the osqueryd process from matching its own SQL query text as a false positive

---

## Files added

### Tier 1 — High priority

Tools in active use across enterprise developer populations, with well-established artifact footprints.

| Detection | macOS | Windows |
|---|---|---|
| Claude AI Assistant (Desktop + Claude Code CLI) | `macOS/claude_ai_assistant_detection.yml` | `Windows/claude_ai_assistant_detection.yml` |
| ChatGPT Desktop | `macOS/chatgpt_desktop_detection.yml` | `Windows/chatgpt_desktop_detection.yml` |
| OpenAI Codex CLI | `macOS/openai_codex_cli_detection.yml` | `Windows/openai_codex_cli_detection.yml` |
| GitHub Copilot | `macOS/github_copilot_detection.yml` | `Windows/github_copilot_detection.yml` |
| Cursor AI Editor | `macOS/cursor_ai_editor_detection.yml` | `Windows/cursor_ai_editor_detection.yml` |
| Windsurf / Codeium | `macOS/windsurf_codeium_detection.yml` | `Windows/windsurf_codeium_detection.yml` |
| Ollama (local LLM server) | `macOS/ollama_local_llm_server_detection.yml` | `Windows/ollama_local_llm_server_detection.yml` |
| Kiro / Amazon Q Developer CLI | `macOS/kiro_amazon_q_detection.yml` | `Windows/kiro_amazon_q_detection.yml` |
| Gemini CLI | `macOS/gemini_cli_detection.yml` | `Windows/gemini_cli_detection.yml` |
| Aider (`aider-chat`) | `macOS/aider_ai_coding_agent_detection.yml` | `Windows/aider_ai_coding_agent_detection.yml` |

### Tier 2 — Medium priority

Noteworthy tools with growing adoption or specific risk characteristics.

| Detection | macOS | Windows |
|---|---|---|
| LM Studio (local LLM GUI) | `macOS/lm_studio_local_llm_detection.yml` | `Windows/lm_studio_local_llm_detection.yml` |
| Jan.ai (local LLM server) | `macOS/jan_ai_local_llm_detection.yml` | `Windows/jan_ai_local_llm_detection.yml` |
| Continue.dev (universal AI coding extension) | `macOS/continue_dev_ai_coding_assistant_detection.yml` | `Windows/continue_dev_ai_coding_assistant_detection.yml` |
| Tabnine | `macOS/tabnine_ai_coding_assistant_detection.yml` | `Windows/tabnine_ai_coding_assistant_detection.yml` |
| Microsoft Copilot (Windows built-in) | — | `Windows/microsoft_copilot_detection.yml` |
| Goose (Block autonomous agent) | `macOS/goose_ai_agent_detection.yml` | `Windows/goose_ai_agent_detection.yml` |
| OpenCode (terminal AI coding agent) | `macOS/opencode_ai_agent_detection.yml` | `Windows/opencode_ai_agent_detection.yml` |
| GPT4All (Nomic AI local LLM) | `macOS/gpt4all_local_llm_detection.yml` | `Windows/gpt4all_local_llm_detection.yml` |
| AnythingLLM (RAG/local AI server) | `macOS/anythingllm_local_server_detection.yml` | `Windows/anythingllm_local_server_detection.yml` |
| llama.cpp / llama-server | `macOS/llamacpp_inference_server_detection.yml` | `Windows/llamacpp_inference_server_detection.yml` |
| Cline / Roo-Cline (VS Code agent) | `macOS/cline_roo_ai_agent_detection.yml` | `Windows/cline_roo_ai_agent_detection.yml` |
| Sourcegraph Cody | `macOS/sourcegraph_cody_detection.yml` | `Windows/sourcegraph_cody_detection.yml` |
| Supermaven (AI code completion) | `macOS/supermaven_ai_completion_detection.yml` | `Windows/supermaven_ai_completion_detection.yml` |

---

## Artifact improvements to existing detections

Based on research of the [agentic-detector](https://github.com/karmine05/agentic-detector) community project, new artifact paths were backfilled into four existing detections on both platforms:

| Detection | New artifact added |
|---|---|
| Claude (macOS + Windows) | `~/Library/Application Support/Claude/claude_desktop_config.json` — MCP server config for Claude Desktop |
| Windsurf (macOS + Windows) | `~/.codeium/windsurf/mcp_config.json` — Windsurf MCP configuration |
| Kiro / Amazon Q (macOS + Windows) | `~/.local/bin/q` / `q.exe` — legacy Amazon Q CLI binary name (pre-Kiro rename) |
| Aider (macOS + Windows) | `~/.local/pipx/venvs/aider-chat/` — pipx installation path (most common install method) |

---

## Signal sources by detection

| Detection | launchd | file | processes | homebrew / choco | npm | apps | ports | docker | prefetch | programs |
|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
| Claude | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | | ✓ | | |
| ChatGPT Desktop | ✓ | ✓ | ✓ | | | ✓ | | ✓ | ✓ | ✓ |
| OpenAI Codex CLI | ✓ | ✓ | ✓ | ✓ | ✓ | | | ✓ | | |
| GitHub Copilot | | ✓ | ✓ | ✓ | ✓ | | | ✓ | | |
| Cursor | ✓ | ✓ | ✓ | | | ✓ | | ✓ | ✓ | ✓ |
| Windsurf / Codeium | ✓ | ✓ | ✓ | ✓ | | ✓ | | ✓ | | |
| Ollama | ✓ | ✓ | ✓ | ✓ | | ✓ | ✓ | ✓ | ✓ | ✓ |
| Kiro / Amazon Q | ✓ | ✓ | ✓ | | | ✓ | | ✓ | ✓ | ✓ |
| Gemini CLI | | ✓ | ✓ | ✓ | ✓ | | | ✓ | ✓ | |
| Aider | | ✓ | ✓ | | | | | ✓ | ✓ | |
| LM Studio | | ✓ | ✓ | ✓ | | ✓ | ✓ | ✓ | ✓ | ✓ |
| Jan.ai | ✓ | ✓ | ✓ | | | ✓ | ✓ | ✓ | ✓ | ✓ |
| Continue.dev | | ✓ | ✓ | | ✓ | | | ✓ | ✓ | |
| Tabnine | | ✓ | ✓ | | | | | ✓ | ✓ | |
| Microsoft Copilot | ✓ | ✓ | ✓ | | | | | | ✓ | ✓ |
| Goose | | ✓ | ✓ | | | | | ✓ | ✓ | |
| OpenCode | | ✓ | ✓ | | ✓ | | | ✓ | ✓ | |
| GPT4All | | ✓ | ✓ | | | ✓ | ✓ | ✓ | ✓ | ✓ |
| AnythingLLM | | ✓ | ✓ | | | ✓ | ✓ | ✓ | ✓ | ✓ |
| llama.cpp | | ✓ | ✓ | ✓ | | | ✓ | ✓ | ✓ | |
| Cline / Roo-Cline | | ✓ | ✓ | | | | | ✓ | ✓ | |
| Sourcegraph Cody | | ✓ | ✓ | | | | | ✓ | ✓ | |
| Supermaven | | ✓ | ✓ | | | | | ✓ | ✓ | |

---

## Notable design decisions

**Local npm install detection** — `file` table with `path LIKE '/Users/%%/node_modules/@pkg/name/package.json'` catches tools installed into local project directories at any depth, since osquery's `%` wildcard crosses path separators. This covers Claude Code, Codex CLI, and Gemini CLI installed in project-local `node_modules/`.

**Kiro / Amazon Q migration** — Kiro is the renamed successor to Amazon Q Developer CLI. Both `~/.kiro/` (new) and `~/.amazonq/` (legacy migration residue) paths are covered, as well as the `amazonwebservices.aws-toolkit-vscode` VS Code extension which ships the Kiro integration. The legacy `q` binary path is also detected.

**Aider** — osquery has no `pip_packages` table, so this detection relies on binary paths (`/usr/local/bin/aider`, `/opt/homebrew/bin/aider`, `~/.local/bin/aider`), pipx venv directories (`~/.local/pipx/venvs/aider-chat/`), config files (`~/.aider.conf.yml`), and the running process name.

**Cline / Roo-Cline VS Code extension detection** — both the `saoudrizwan.claude-dev` (Cline) and `rooveterinaryinc.roo-cline` (Roo-Cline) extension IDs are covered in a single detection. Extension install directories are readable without Full Disk Access; `globalStorage` paths require Full Disk Access and confirm active usage beyond mere installation.

**llama.cpp port guard** — the default llama-server port (8080) is too common to use alone; the listening_ports CTE requires `AND path LIKE '%llama%'` to ensure only the llama-server process triggers it.

**AnythingLLM and GPT4All port guards** — ports 3001 and 4891 respectively are similarly guarded with path filters to avoid false positives from unrelated services.

**Microsoft Copilot false-positive guard** — all CTEs exclude paths and names matching `%GitHub%` and `%Extensions%` to prevent GitHub Copilot artifacts from triggering this detection, since both tools are commonly installed on developer machines simultaneously.

**Cursor false-positive guard** — `CursorUIViewService` (macOS system process at `/System/Library/...`) and `SSAssistanceCursor.app` (bundle ID `com.apple.SSAssistanceCursor`) both match `%cursor%`. Guards added: `AND path NOT LIKE '/System/%'` in processes and `AND bundle_identifier NOT LIKE 'com.apple.%'` in apps.

---

## References

- [Okta — Detecting OpenClaw with Advanced Posture Checks](https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/)
- [Okta — Introducing Advanced Posture Checks](https://support.okta.com/help/s/blog/a67KZ000000oLyAYAU/introducing-advanced-posture-checks-for-device-compliance-enforcement)
- [osquery schema 5.23.1](https://github.com/osquery/osquery-site/blob/main/src/data/osquery_schema_versions/5.23.1.json)
- [agentic-detector community research](https://github.com/karmine05/agentic-detector)
