### PR TITLE
Add Kimi Code AI coding agent detection checks for macOS and Windows

### DIFF
--- a/sample_osquery_checks/Windows/kimi_code_ai_agent_detection.yml
+++ b/sample_osquery_checks/Windows/kimi_code_ai_agent_detection.yml
@@ -1,0 +1,81 @@
+title: Kimi Code AI Coding Agent Detection
+id: af16d57d8f7e4298b0b595e5b9afaed6
+description: |
+    Detects the presence of Kimi Code, an agentic AI coding tool developed by MoonshotAI (makers
+    of the Kimi AI assistant), on Windows devices. Kimi Code runs in the terminal and can
+    autonomously read and edit code, execute shell commands, search files, fetch web pages, and
+    interact with MCP servers on the user's behalf. All interactions and code context are
+    transmitted to MoonshotAI's servers. The tool is distributed as a single binary via a native
+    install script (PowerShell irm | iex), or the npm package @moonshot-ai/kimi-code. The binary
+    is named `kimi.exe` and the internal process name is `kimi-code`. User-level configuration is
+    stored under %USERPROFILE%\.kimi-code\, including config.toml, tui.toml, and mcp.json. This
+    detection evaluates file paths, running processes, Chocolatey packages, npm packages, prefetch
+    entries, and active network sockets to identify Kimi Code installations. A score greater than 1
+    (at least two positive indicators) is required to confirm detection.
+references:
+    - https://github.com/MoonshotAI/kimi-code
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: Windows
+query: |
+    WITH file_kimi AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '%\Users\%%\.kimi-code\config.toml'
+            OR path LIKE '%\Users\%%\.kimi-code\tui.toml'
+            OR path LIKE '%\Users\%%\.kimi-code\mcp.json'
+            OR path LIKE '%\Users\%%\.kimi-code\bin\kimi.exe'
+            OR path LIKE '%\Users\%%\AppData\Roaming\npm\node_modules\@moonshot-ai\kimi-code\package.json'
+            OR path LIKE '%\Users\%%\node_modules\@moonshot-ai\kimi-code\package.json'
+    ),
+    process_kimi AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'kimi.exe'
+            OR name = 'kimi'
+            OR name = 'kimi-code.exe'
+            OR cmdline LIKE '%\@moonshot-ai\kimi-code\%'
+            OR cmdline LIKE '%\node_modules\.bin\kimi %'
+    ),
+    choco_kimi AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM chocolatey_packages
+        WHERE name = 'kimi-code'
+    ),
+    npm_kimi AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM npm_packages
+        WHERE name LIKE '%moonshot-ai/kimi-code%'
+    ),
+    prefetch_kimi AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM prefetch
+        WHERE path LIKE '%\kimi-code%'
+            OR path LIKE '%\kimi.exe%'
+    ),
+    sockets_kimi AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM process_open_sockets
+        WHERE path LIKE '%\kimi-code%'
+            OR path LIKE '%\kimi.exe%'
+    ),
+    final_score AS (
+        SELECT
+            file_kimi.total
+            + process_kimi.total
+            + choco_kimi.total
+            + npm_kimi.total
+            + prefetch_kimi.total
+            + sockets_kimi.total
+            AS score
+        FROM file_kimi, process_kimi, choco_kimi, npm_kimi,
+             prefetch_kimi, sockets_kimi
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS kimi_code_detected
+    FROM final_score
+    ;

--- a/sample_osquery_checks/macOS/kimi_code_ai_agent_detection.yml
+++ b/sample_osquery_checks/macOS/kimi_code_ai_agent_detection.yml
@@ -1,0 +1,81 @@
+title: Kimi Code AI Coding Agent Detection
+id: 2d5194aa67a4480390fc2e7cc9b67213
+description: |
+    Detects the presence of Kimi Code, an agentic AI coding tool developed by MoonshotAI (makers
+    of the Kimi AI assistant), on macOS devices. Kimi Code runs in the terminal and can
+    autonomously read and edit code, execute shell commands, search files, fetch web pages, and
+    interact with MCP servers on the user's behalf. All interactions and code context are
+    transmitted to MoonshotAI's servers. The tool is distributed as a single binary via a native
+    install script (curl | bash), Homebrew, or the npm package @moonshot-ai/kimi-code. The binary
+    is named `kimi` and the internal process name is `kimi-code`. User-level configuration is
+    stored under ~/.kimi-code/, including config.toml, tui.toml, and mcp.json. This detection
+    evaluates file paths, running processes, Homebrew packages, npm packages, and Docker artifacts
+    to identify Kimi Code installations. A score greater than 1 (at least two positive indicators)
+    is required to confirm detection.
+references:
+    - https://github.com/MoonshotAI/kimi-code
+    - https://www.okta.com/blog/threat-intelligence/detecting-openclaw-advanced-posture-checks/
+author:
+    - rafa.bono@okta.com
+platform: macOS
+query: |
+    WITH file_kimi AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM file
+        WHERE path LIKE '/Users/%%/.kimi-code/config.toml'
+            OR path LIKE '/Users/%%/.kimi-code/tui.toml'
+            OR path LIKE '/Users/%%/.kimi-code/mcp.json'
+            OR path LIKE '/Users/%%/.kimi-code/bin/kimi'
+            OR path LIKE '/opt/homebrew/bin/kimi'
+            OR path LIKE '/usr/local/bin/kimi'
+            OR path LIKE '/Users/%%/node_modules/@moonshot-ai/kimi-code/package.json'
+    ),
+    process_kimi AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM processes
+        WHERE name = 'kimi'
+            OR name = 'kimi-code'
+            OR cmdline LIKE '%/@moonshot-ai/kimi-code/%'
+            OR cmdline LIKE '%/node_modules/.bin/kimi %'
+    ),
+    homebrew_kimi AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM homebrew_packages
+        WHERE name = 'kimi-code'
+    ),
+    npm_kimi AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM npm_packages
+        WHERE name LIKE '%moonshot-ai/kimi-code%'
+    ),
+    docker_image_kimi AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_images
+        WHERE tags LIKE '%kimi-code%'
+            OR tags LIKE '%moonshot-ai%'
+    ),
+    docker_container_kimi AS (
+        SELECT COALESCE(COUNT(*), 0) AS total
+        FROM docker_containers
+        WHERE image LIKE '%kimi-code%'
+            OR image LIKE '%moonshot-ai%'
+    ),
+    final_score AS (
+        SELECT
+            file_kimi.total
+            + process_kimi.total
+            + homebrew_kimi.total
+            + npm_kimi.total
+            + docker_image_kimi.total
+            + docker_container_kimi.total
+            AS score
+        FROM file_kimi, process_kimi, homebrew_kimi, npm_kimi,
+             docker_image_kimi, docker_container_kimi
+    )
+    SELECT
+        CASE
+            WHEN score <= 1 THEN 0
+            WHEN score > 1 THEN 1
+        END AS kimi_code_detected
+    FROM final_score
+    ;


### PR DESCRIPTION
## Summary

Adds osquery-based Advanced Posture Check (APC) detections for **Kimi Code**, an agentic AI coding tool developed by MoonshotAI (makers of the Kimi AI assistant). Kimi Code is functionally similar to Claude Code and Gemini CLI — it runs in the terminal and can autonomously read and edit files, execute shell commands, search the codebase, fetch web pages, and interact with MCP servers. All interactions and code context are transmitted to MoonshotAI's servers.

### Files added

| File | Platform |
|------|----------|
| `sample_osquery_checks/macOS/kimi_code_ai_agent_detection.yml` | macOS |
| `sample_osquery_checks/Windows/kimi_code_ai_agent_detection.yml` | Windows |

### Detection signals

**macOS** — scores across 6 independent signal sources:
- **File paths**: `~/.kimi-code/config.toml`, `tui.toml`, `mcp.json`, `bin/kimi` (native install), `/opt/homebrew/bin/kimi`, `/usr/local/bin/kimi`, local node_modules path
- **Processes**: process name `kimi` or `kimi-code`, cmdline patterns matching npm install layouts
- **Homebrew**: package name `kimi-code`
- **npm packages**: `@moonshot-ai/kimi-code`
- **Docker images/containers**: tags or image name containing `kimi-code` or `moonshot-ai`

**Windows** — scores across 6 independent signal sources:
- **File paths**: `%USERPROFILE%\.kimi-code\` config files, `bin\kimi.exe` (native install), npm global install paths under `AppData\Roaming\npm`
- **Processes**: `kimi.exe`, `kimi`, `kimi-code.exe`, cmdline patterns matching npm install layouts
- **Chocolatey**: package name `kimi-code`
- **npm packages**: `@moonshot-ai/kimi-code`
- **Prefetch / process_open_sockets**: paths containing `kimi-code` or `kimi.exe` (avoiding bare `kimi` to reduce false positives)

### Threshold

Both checks use the standard `score > 1` threshold, requiring at least **two independent signals** before flagging a detection. This reduces false positives from coincidental name matches.

### Key artifacts (from source)

- Binary: `kimi` / `kimi.exe`
- Internal process name: `kimi-code` (defined in `apps/kimi-code/src/constant/app.ts`)
- npm package: `@moonshot-ai/kimi-code`
- Config directory: `~/.kimi-code/` (macOS/Linux), `%USERPROFILE%\.kimi-code\` (Windows)
- Install methods: native script (`curl | bash` / `irm | iex`), Homebrew, npm global

### References
- https://github.com/MoonshotAI/kimi-code