### PR TITLE
fix: correct osquery file table %% mid-path wildcard across sample checks

### DIFF
--- a/sample_osquery_checks/Cross/bufferzonecorp_campaign_detection.yml
+++ b/sample_osquery_checks/Cross/bufferzonecorp_campaign_detection.yml
@@ -40,10 +40,10 @@ query: |
   WITH ruby_gems AS (
       SELECT COALESCE(COUNT(*), 0) AS total
       FROM file
-      WHERE path LIKE '/usr/%%/gems/knot-%'
-         OR path LIKE '/opt/%%/gems/knot-%'
-         OR path LIKE '/home/%%/gems/knot-%'
-         OR path LIKE '/Users/%%/gems/knot-%'
+      WHERE path LIKE '/usr/%/gems/knot-%'
+         OR path LIKE '/opt/%/gems/knot-%'
+         OR path LIKE '/home/%/gems/knot-%'
+         OR path LIKE '/Users/%/gems/knot-%'
   ),
   ssh_backdoor AS (
       SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Cross/keyv_npm_worm_gh_token_monitor_detection.yml
+++ b/sample_osquery_checks/Cross/keyv_npm_worm_gh_token_monitor_detection.yml
@@ -106,12 +106,12 @@ query: |
   persistence_signal AS (
       SELECT COALESCE(COUNT(*), 0) AS total
       FROM file
-      WHERE path LIKE '/Users/%%/.local/bin/gh-token-monitor.sh'
-         OR path LIKE '/home/%%/.local/bin/gh-token-monitor.sh'
-         OR path LIKE '/Users/%%/Library/LaunchAgents/com.user.gh-token-monitor.plist'
-         OR path LIKE '/Users/%%/.config/gh-token-monitor/token'
-         OR path LIKE '/home/%%/.config/gh-token-monitor/token'
-         OR path LIKE '/home/%%/.config/systemd/user/gh-token-monitor.service'
+      WHERE path LIKE '/Users/%/.local/bin/gh-token-monitor.sh'
+         OR path LIKE '/home/%/.local/bin/gh-token-monitor.sh'
+         OR path LIKE '/Users/%/Library/LaunchAgents/com.user.gh-token-monitor.plist'
+         OR path LIKE '/Users/%/.config/gh-token-monitor/token'
+         OR path LIKE '/home/%/.config/gh-token-monitor/token'
+         OR path LIKE '/home/%/.config/systemd/user/gh-token-monitor.service'
   ),
   final_score AS (
       SELECT

--- a/sample_osquery_checks/Windows/aider_ai_coding_agent_detection.yml
+++ b/sample_osquery_checks/Windows/aider_ai_coding_agent_detection.yml
@@ -25,11 +25,11 @@ query: |
         FROM file
         -- Python Scripts directories (global and user installs)
         WHERE path LIKE '%\Scripts\aider.exe'
-            OR path LIKE '%\Users\%%\.aider\.aider.conf.yml'
-            OR path LIKE '%\Users\%%\.aider.conf.yml'
-            OR path LIKE '%\Users\%%\.aider\analytics.json'
+            OR path LIKE '%\Users\%\.aider\.aider.conf.yml'
+            OR path LIKE '%\Users\%\.aider.conf.yml'
+            OR path LIKE '%\Users\%\.aider\analytics.json'
             -- pipx installation
-            OR path LIKE '%\Users\%%\.local\pipx\venvs\aider-chat\%'
+            OR path LIKE '%\Users\%\.local\pipx\venvs\aider-chat\%'
     ),
     process_aider AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/anythingllm_local_server_detection.yml
+++ b/sample_osquery_checks/Windows/anythingllm_local_server_detection.yml
@@ -23,9 +23,9 @@ query: |
     WITH file_anyllm AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '%\Users\%%\AppData\Local\Programs\AnythingLLM Desktop\AnythingLLM Desktop.exe'
-            OR path LIKE '%\Users\%%\AppData\Roaming\anythingllm-desktop\%'
-            OR path LIKE '%\Users\%%\AppData\Local\AnythingLLM\%'
+        WHERE path LIKE '%\Users\%\AppData\Local\Programs\AnythingLLM Desktop\AnythingLLM Desktop.exe'
+            OR path LIKE '%\Users\%\AppData\Roaming\anythingllm-desktop\%'
+            OR path LIKE '%\Users\%\AppData\Local\AnythingLLM\%'
     ),
     process_anyllm AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/chatgpt_desktop_detection.yml
+++ b/sample_osquery_checks/Windows/chatgpt_desktop_detection.yml
@@ -27,9 +27,9 @@ query: |
     file_chatgpt AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '%\Users\%%\AppData\Local\OpenAI\ChatGPT\%'
-            OR path LIKE '%\Users\%%\AppData\Roaming\OpenAI\ChatGPT\%'
-            OR path LIKE '%\Users\%%\AppData\Local\Programs\ChatGPT\ChatGPT.exe'
+        WHERE path LIKE '%\Users\%\AppData\Local\OpenAI\ChatGPT\%'
+            OR path LIKE '%\Users\%\AppData\Roaming\OpenAI\ChatGPT\%'
+            OR path LIKE '%\Users\%\AppData\Local\Programs\ChatGPT\ChatGPT.exe'
     ),
     process_chatgpt AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/claude_ai_assistant_detection.yml
+++ b/sample_osquery_checks/Windows/claude_ai_assistant_detection.yml
@@ -28,12 +28,12 @@ query: |
     file_claude AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '%\Users\%%\.claude\settings.json'
-            OR path LIKE '%\Users\%%\.claude\CLAUDE.md'
-            OR path LIKE '%\Users\%%\AppData\Local\AnthropicClaude\%'
-            OR path LIKE '%\Users\%%\AppData\Roaming\Claude\%'
-            OR path LIKE '%\Users\%%\AppData\Roaming\npm\node_modules\@anthropic-ai\claude-code\package.json'
-            OR path LIKE '%\Users\%%\node_modules\@anthropic-ai\claude-code\package.json'
+        WHERE path LIKE '%\Users\%\.claude\settings.json'
+            OR path LIKE '%\Users\%\.claude\CLAUDE.md'
+            OR path LIKE '%\Users\%\AppData\Local\AnthropicClaude\%'
+            OR path LIKE '%\Users\%\AppData\Roaming\Claude\%'
+            OR path LIKE '%\Users\%\AppData\Roaming\npm\node_modules\@anthropic-ai\claude-code\package.json'
+            OR path LIKE '%\Users\%\node_modules\@anthropic-ai\claude-code\package.json'
     ),
     process_claude AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/cline_roo_ai_agent_detection.yml
+++ b/sample_osquery_checks/Windows/cline_roo_ai_agent_detection.yml
@@ -25,14 +25,14 @@ query: |
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
         -- VS Code extension directories (Cline and Roo-Cline)
-        WHERE path LIKE '%\Users\%%\.vscode\extensions\saoudrizwan.claude-dev-%'
-            OR path LIKE '%\Users\%%\.vscode\extensions\rooveterinaryinc.roo-cline-%'
+        WHERE path LIKE '%\Users\%\.vscode\extensions\saoudrizwan.claude-dev-%'
+            OR path LIKE '%\Users\%\.vscode\extensions\rooveterinaryinc.roo-cline-%'
             -- Cursor extension directories
-            OR path LIKE '%\Users\%%\.cursor\extensions\saoudrizwan.claude-dev-%'
-            OR path LIKE '%\Users\%%\.cursor\extensions\rooveterinaryinc.roo-cline-%'
+            OR path LIKE '%\Users\%\.cursor\extensions\saoudrizwan.claude-dev-%'
+            OR path LIKE '%\Users\%\.cursor\extensions\rooveterinaryinc.roo-cline-%'
             -- VS Code global storage confirms active usage
-            OR path LIKE '%\Users\%%\AppData\Roaming\Code\User\globalStorage\saoudrizwan.claude-dev\%'
-            OR path LIKE '%\Users\%%\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\%'
+            OR path LIKE '%\Users\%\AppData\Roaming\Code\User\globalStorage\saoudrizwan.claude-dev\%'
+            OR path LIKE '%\Users\%\AppData\Roaming\Code\User\globalStorage\rooveterinaryinc.roo-cline\%'
     ),
     process_cline AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/continue_dev_ai_coding_assistant_detection.yml
+++ b/sample_osquery_checks/Windows/continue_dev_ai_coding_assistant_detection.yml
@@ -24,11 +24,11 @@ query: |
     WITH file_continue AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '%\Users\%%\.continue\config.yaml'
-            OR path LIKE '%\Users\%%\.continue\config.json'
-            OR path LIKE '%\Users\%%\.continue\config.ts'
+        WHERE path LIKE '%\Users\%\.continue\config.yaml'
+            OR path LIKE '%\Users\%\.continue\config.json'
+            OR path LIKE '%\Users\%\.continue\config.ts'
             -- VS Code extension directory
-            OR path LIKE '%\Users\%%\.vscode\extensions\continue.continue-%'
+            OR path LIKE '%\Users\%\.vscode\extensions\continue.continue-%'
     ),
     process_continue AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/cursor_ai_editor_detection.yml
+++ b/sample_osquery_checks/Windows/cursor_ai_editor_detection.yml
@@ -27,10 +27,10 @@ query: |
     file_cursor AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '%\Users\%%\AppData\Local\Programs\cursor\Cursor.exe'
-            OR path LIKE '%\Users\%%\AppData\Local\cursor\%'
-            OR path LIKE '%\Users\%%\.cursor\mcp.json'
-            OR path LIKE '%\Users\%%\AppData\Roaming\Cursor\User\settings.json'
+        WHERE path LIKE '%\Users\%\AppData\Local\Programs\cursor\Cursor.exe'
+            OR path LIKE '%\Users\%\AppData\Local\cursor\%'
+            OR path LIKE '%\Users\%\.cursor\mcp.json'
+            OR path LIKE '%\Users\%\AppData\Roaming\Cursor\User\settings.json'
     ),
     process_cursor AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/gemini_cli_detection.yml
+++ b/sample_osquery_checks/Windows/gemini_cli_detection.yml
@@ -23,10 +23,10 @@ query: |
     WITH file_gemini AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '%\Users\%%\AppData\Roaming\GeminiCli\settings.json'
-            OR path LIKE '%\Users\%%\AppData\Roaming\npm\node_modules\@google\gemini-cli\package.json'
-            OR path LIKE '%\Users\%%\node_modules\@google\gemini-cli\package.json'
-            OR path LIKE '%\Users\%%\AppData\Roaming\npm\gemini'
+        WHERE path LIKE '%\Users\%\AppData\Roaming\GeminiCli\settings.json'
+            OR path LIKE '%\Users\%\AppData\Roaming\npm\node_modules\@google\gemini-cli\package.json'
+            OR path LIKE '%\Users\%\node_modules\@google\gemini-cli\package.json'
+            OR path LIKE '%\Users\%\AppData\Roaming\npm\gemini'
     ),
     process_gemini AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/github_copilot_detection.yml
+++ b/sample_osquery_checks/Windows/github_copilot_detection.yml
@@ -20,12 +20,12 @@ query: |
     WITH file_copilot AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '%\Users\%%\.vscode\extensions\github.copilot-%'
-            OR path LIKE '%\Users\%%\.vscode\extensions\github.copilot-chat-%'
-            OR path LIKE '%\Users\%%\.config\github-copilot\hosts.json'
-            OR path LIKE '%\Users\%%\.config\github-copilot\apps.json'
-            OR path LIKE '%\Users\%%\AppData\Roaming\npm\node_modules\@github\copilot-language-server\package.json'
-            OR path LIKE '%\Users\%%\node_modules\@github\copilot-language-server\package.json'
+        WHERE path LIKE '%\Users\%\.vscode\extensions\github.copilot-%'
+            OR path LIKE '%\Users\%\.vscode\extensions\github.copilot-chat-%'
+            OR path LIKE '%\Users\%\.config\github-copilot\hosts.json'
+            OR path LIKE '%\Users\%\.config\github-copilot\apps.json'
+            OR path LIKE '%\Users\%\AppData\Roaming\npm\node_modules\@github\copilot-language-server\package.json'
+            OR path LIKE '%\Users\%\node_modules\@github\copilot-language-server\package.json'
     ),
     process_copilot AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/goose_ai_agent_detection.yml
+++ b/sample_osquery_checks/Windows/goose_ai_agent_detection.yml
@@ -26,10 +26,10 @@ query: |
     WITH file_goose AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '%\Users\%%\.local\bin\goose.exe'
-            OR path LIKE '%\Users\%%\AppData\Roaming\goose\profiles.yaml'
-            OR path LIKE '%\Users\%%\AppData\Roaming\goose\config.yaml'
-            OR path LIKE '%\Users\%%\AppData\Local\goose\sessions\%'
+        WHERE path LIKE '%\Users\%\.local\bin\goose.exe'
+            OR path LIKE '%\Users\%\AppData\Roaming\goose\profiles.yaml'
+            OR path LIKE '%\Users\%\AppData\Roaming\goose\config.yaml'
+            OR path LIKE '%\Users\%\AppData\Local\goose\sessions\%'
     ),
     process_goose AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/gpt4all_local_llm_detection.yml
+++ b/sample_osquery_checks/Windows/gpt4all_local_llm_detection.yml
@@ -22,9 +22,9 @@ query: |
     WITH file_gpt4all AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '%\Users\%%\AppData\Local\Programs\GPT4All\GPT4All.exe'
-            OR path LIKE '%\Users\%%\AppData\Local\nomic.ai\GPT4All\%'
-            OR path LIKE '%\Users\%%\AppData\Local\GPT4All\%'
+        WHERE path LIKE '%\Users\%\AppData\Local\Programs\GPT4All\GPT4All.exe'
+            OR path LIKE '%\Users\%\AppData\Local\nomic.ai\GPT4All\%'
+            OR path LIKE '%\Users\%\AppData\Local\GPT4All\%'
     ),
     process_gpt4all AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/jan_ai_local_llm_detection.yml
+++ b/sample_osquery_checks/Windows/jan_ai_local_llm_detection.yml
@@ -28,10 +28,10 @@ query: |
     file_jan AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '%\Users\%%\AppData\Local\Programs\Jan\Jan.exe'
-            OR path LIKE '%\Users\%%\.jan\models\%'
-            OR path LIKE '%\Users\%%\.jan\settings.json'
-            OR path LIKE '%\Users\%%\AppData\Roaming\Jan\%'
+        WHERE path LIKE '%\Users\%\AppData\Local\Programs\Jan\Jan.exe'
+            OR path LIKE '%\Users\%\.jan\models\%'
+            OR path LIKE '%\Users\%\.jan\settings.json'
+            OR path LIKE '%\Users\%\AppData\Roaming\Jan\%'
     ),
     process_jan AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/kimi_code_ai_agent_detection.yml
+++ b/sample_osquery_checks/Windows/kimi_code_ai_agent_detection.yml
@@ -22,12 +22,12 @@ query: |
     WITH file_kimi AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '%\Users\%%\.kimi-code\config.toml'
-            OR path LIKE '%\Users\%%\.kimi-code\tui.toml'
-            OR path LIKE '%\Users\%%\.kimi-code\mcp.json'
-            OR path LIKE '%\Users\%%\.kimi-code\bin\kimi.exe'
-            OR path LIKE '%\Users\%%\AppData\Roaming\npm\node_modules\@moonshot-ai\kimi-code\package.json'
-            OR path LIKE '%\Users\%%\node_modules\@moonshot-ai\kimi-code\package.json'
+        WHERE path LIKE '%\Users\%\.kimi-code\config.toml'
+            OR path LIKE '%\Users\%\.kimi-code\tui.toml'
+            OR path LIKE '%\Users\%\.kimi-code\mcp.json'
+            OR path LIKE '%\Users\%\.kimi-code\bin\kimi.exe'
+            OR path LIKE '%\Users\%\AppData\Roaming\npm\node_modules\@moonshot-ai\kimi-code\package.json'
+            OR path LIKE '%\Users\%\node_modules\@moonshot-ai\kimi-code\package.json'
     ),
     process_kimi AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/kiro_amazon_q_detection.yml
+++ b/sample_osquery_checks/Windows/kiro_amazon_q_detection.yml
@@ -30,15 +30,15 @@ query: |
     file_kiro AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '%\Users\%%\AppData\Local\Programs\Kiro\Kiro.exe'
-            OR path LIKE '%\Users\%%\.kiro\settings\cli.json'
-            OR path LIKE '%\Users\%%\.kiro\settings\mcp.json'
+        WHERE path LIKE '%\Users\%\AppData\Local\Programs\Kiro\Kiro.exe'
+            OR path LIKE '%\Users\%\.kiro\settings\cli.json'
+            OR path LIKE '%\Users\%\.kiro\settings\mcp.json'
             -- Legacy Amazon Q Developer paths (pre-migration)
-            OR path LIKE '%\Users\%%\.amazonq\scopes\scope.json'
+            OR path LIKE '%\Users\%\.amazonq\scopes\scope.json'
             -- AWS Toolkit VS Code extension (ships Kiro/Q integration)
-            OR path LIKE '%\Users\%%\.vscode\extensions\amazonwebservices.aws-toolkit-vscode-%'
+            OR path LIKE '%\Users\%\.vscode\extensions\amazonwebservices.aws-toolkit-vscode-%'
             -- Legacy Amazon Q CLI binary (named q)
-            OR path LIKE '%\Users\%%\.local\bin\q.exe'
+            OR path LIKE '%\Users\%\.local\bin\q.exe'
     ),
     process_kiro AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/lm_studio_local_llm_detection.yml
+++ b/sample_osquery_checks/Windows/lm_studio_local_llm_detection.yml
@@ -30,10 +30,10 @@ query: |
     file_lmstudio AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '%\Users\%%\AppData\Local\Programs\LM Studio\LM Studio.exe'
-            OR path LIKE '%\Users\%%\.lmstudio\models\%'
-            OR path LIKE '%\Users\%%\.lmstudio\config.json'
-            OR path LIKE '%\Users\%%\AppData\Roaming\LM Studio\%'
+        WHERE path LIKE '%\Users\%\AppData\Local\Programs\LM Studio\LM Studio.exe'
+            OR path LIKE '%\Users\%\.lmstudio\models\%'
+            OR path LIKE '%\Users\%\.lmstudio\config.json'
+            OR path LIKE '%\Users\%\AppData\Roaming\LM Studio\%'
     ),
     process_lmstudio AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/microsoft_copilot_detection.yml
+++ b/sample_osquery_checks/Windows/microsoft_copilot_detection.yml
@@ -25,8 +25,8 @@ query: |
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
         -- MSIX/UWP package store path
-        WHERE path LIKE '%\Users\%%\AppData\Local\Packages\Microsoft.Copilot_%'
-            OR path LIKE '%\Users\%%\AppData\Local\Microsoft\WindowsApps\Copilot.exe'
+        WHERE path LIKE '%\Users\%\AppData\Local\Packages\Microsoft.Copilot_%'
+            OR path LIKE '%\Users\%\AppData\Local\Microsoft\WindowsApps\Copilot.exe'
     ),
     startup_mscopilot AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/ollama_local_llm_server_detection.yml
+++ b/sample_osquery_checks/Windows/ollama_local_llm_server_detection.yml
@@ -29,9 +29,9 @@ query: |
     file_ollama AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '%\Users\%%\AppData\Local\Programs\Ollama\ollama.exe'
-            OR path LIKE '%\Users\%%\AppData\Local\Ollama\%'
-            OR path LIKE '%\Users\%%\.ollama\models\%'
+        WHERE path LIKE '%\Users\%\AppData\Local\Programs\Ollama\ollama.exe'
+            OR path LIKE '%\Users\%\AppData\Local\Ollama\%'
+            OR path LIKE '%\Users\%\.ollama\models\%'
     ),
     process_ollama AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/openai_codex_cli_detection.yml
+++ b/sample_osquery_checks/Windows/openai_codex_cli_detection.yml
@@ -20,9 +20,9 @@ query: |
     WITH file_codex AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '%\Users\%%\.codex\config.json'
-            OR path LIKE '%\Users\%%\AppData\Roaming\npm\node_modules\@openai\codex\package.json'
-            OR path LIKE '%\Users\%%\node_modules\@openai\codex\package.json'
+        WHERE path LIKE '%\Users\%\.codex\config.json'
+            OR path LIKE '%\Users\%\AppData\Roaming\npm\node_modules\@openai\codex\package.json'
+            OR path LIKE '%\Users\%\node_modules\@openai\codex\package.json'
     ),
     process_codex AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/openclaw_personal_ai_assistant_detection.yml
+++ b/sample_osquery_checks/Windows/openclaw_personal_ai_assistant_detection.yml
@@ -16,7 +16,7 @@ query: |
     file_claw AS (
         SELECT COALESCE(COUNT(*), 0) as total
         FROM file
-        WHERE path LIKE '%\Users\%%\.openclaw\'
+        WHERE path LIKE '%\Users\%\.openclaw\'
         ),
     claw_process AS (
         SELECT COALESCE(COUNT(*), 0) as total

--- a/sample_osquery_checks/Windows/opencode_ai_agent_detection.yml
+++ b/sample_osquery_checks/Windows/opencode_ai_agent_detection.yml
@@ -21,11 +21,11 @@ query: |
     WITH file_opencode AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '%\Users\%%\AppData\Roaming\npm\opencode'
-            OR path LIKE '%\Users\%%\AppData\Roaming\npm\node_modules\opencode-ai\package.json'
-            OR path LIKE '%\Users\%%\AppData\Roaming\opencode\config.json'
-            OR path LIKE '%\Users\%%\AppData\Roaming\opencode\config.jsonc'
-            OR path LIKE '%\Users\%%\node_modules\opencode-ai\package.json'
+        WHERE path LIKE '%\Users\%\AppData\Roaming\npm\opencode'
+            OR path LIKE '%\Users\%\AppData\Roaming\npm\node_modules\opencode-ai\package.json'
+            OR path LIKE '%\Users\%\AppData\Roaming\opencode\config.json'
+            OR path LIKE '%\Users\%\AppData\Roaming\opencode\config.jsonc'
+            OR path LIKE '%\Users\%\node_modules\opencode-ai\package.json'
     ),
     process_opencode AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/sourcegraph_cody_detection.yml
+++ b/sample_osquery_checks/Windows/sourcegraph_cody_detection.yml
@@ -22,10 +22,10 @@ query: |
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
         -- VS Code and Cursor extension directories
-        WHERE path LIKE '%\Users\%%\.vscode\extensions\sourcegraph.cody-ai-%'
-            OR path LIKE '%\Users\%%\.cursor\extensions\sourcegraph.cody-ai-%'
+        WHERE path LIKE '%\Users\%\.vscode\extensions\sourcegraph.cody-ai-%'
+            OR path LIKE '%\Users\%\.cursor\extensions\sourcegraph.cody-ai-%'
             -- VS Code global storage confirms active usage
-            OR path LIKE '%\Users\%%\AppData\Roaming\Code\User\globalStorage\sourcegraph.cody-ai\%'
+            OR path LIKE '%\Users\%\AppData\Roaming\Code\User\globalStorage\sourcegraph.cody-ai\%'
     ),
     process_cody AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/supermaven_ai_completion_detection.yml
+++ b/sample_osquery_checks/Windows/supermaven_ai_completion_detection.yml
@@ -23,12 +23,12 @@ query: |
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
         -- VS Code and Cursor extension directories
-        WHERE path LIKE '%\Users\%%\.vscode\extensions\supermaven.supermaven-%'
-            OR path LIKE '%\Users\%%\.cursor\extensions\supermaven.supermaven-%'
+        WHERE path LIKE '%\Users\%\.vscode\extensions\supermaven.supermaven-%'
+            OR path LIKE '%\Users\%\.cursor\extensions\supermaven.supermaven-%'
             -- VS Code global storage and app data
-            OR path LIKE '%\Users\%%\AppData\Roaming\Code\User\globalStorage\supermaven.supermaven\%'
-            OR path LIKE '%\Users\%%\AppData\Roaming\Supermaven\%'
-            OR path LIKE '%\Users\%%\AppData\Local\Supermaven\%'
+            OR path LIKE '%\Users\%\AppData\Roaming\Code\User\globalStorage\supermaven.supermaven\%'
+            OR path LIKE '%\Users\%\AppData\Roaming\Supermaven\%'
+            OR path LIKE '%\Users\%\AppData\Local\Supermaven\%'
     ),
     process_supermaven AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/tabnine_ai_coding_assistant_detection.yml
+++ b/sample_osquery_checks/Windows/tabnine_ai_coding_assistant_detection.yml
@@ -25,12 +25,12 @@ query: |
     WITH file_tabnine AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '%\Users\%%\.tabninecache\%'
-            OR path LIKE '%\Users\%%\.tabnine\%'
+        WHERE path LIKE '%\Users\%\.tabninecache\%'
+            OR path LIKE '%\Users\%\.tabnine\%'
             -- VS Code extension
-            OR path LIKE '%\Users\%%\.vscode\extensions\tabnine.tabnine-vscode-%'
+            OR path LIKE '%\Users\%\.vscode\extensions\tabnine.tabnine-vscode-%'
             -- JetBrains plugin
-            OR path LIKE '%\Users\%%\AppData\Roaming\JetBrains\%%\plugins\tabnine-jetbrains\%'
+            OR path LIKE '%\Users\%\AppData\Roaming\JetBrains\%\plugins\tabnine-jetbrains\%'
     ),
     process_tabnine AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/Windows/windsurf_codeium_detection.yml
+++ b/sample_osquery_checks/Windows/windsurf_codeium_detection.yml
@@ -27,13 +27,13 @@ query: |
     file_windsurf AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '%\Users\%%\AppData\Local\Programs\windsurf\Windsurf.exe'
-            OR path LIKE '%\Users\%%\AppData\Local\windsurf\%'
-            OR path LIKE '%\Users\%%\AppData\Roaming\Windsurf\User\settings.json'
-            OR path LIKE '%\Users\%%\.codeium\config.json'
-            OR path LIKE '%\Users\%%\.windsurf\%'
+        WHERE path LIKE '%\Users\%\AppData\Local\Programs\windsurf\Windsurf.exe'
+            OR path LIKE '%\Users\%\AppData\Local\windsurf\%'
+            OR path LIKE '%\Users\%\AppData\Roaming\Windsurf\User\settings.json'
+            OR path LIKE '%\Users\%\.codeium\config.json'
+            OR path LIKE '%\Users\%\.windsurf\%'
             -- MCP configuration
-            OR path LIKE '%\Users\%%\.codeium\windsurf\mcp_config.json'
+            OR path LIKE '%\Users\%\.codeium\windsurf\mcp_config.json'
     ),
     process_windsurf AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/aider_ai_coding_agent_detection.yml
+++ b/sample_osquery_checks/macOS/aider_ai_coding_agent_detection.yml
@@ -25,12 +25,12 @@ query: |
         FROM file
         WHERE path LIKE '/usr/local/bin/aider'
             OR path LIKE '/opt/homebrew/bin/aider'
-            OR path LIKE '/Users/%%/.local/bin/aider'
-            OR path LIKE '/Users/%%/.aider/.aider.conf.yml'
-            OR path LIKE '/Users/%%/.aider.conf.yml'
-            OR path LIKE '/Users/%%/.aider/analytics.json'
+            OR path LIKE '/Users/%/.local/bin/aider'
+            OR path LIKE '/Users/%/.aider/.aider.conf.yml'
+            OR path LIKE '/Users/%/.aider.conf.yml'
+            OR path LIKE '/Users/%/.aider/analytics.json'
             -- pipx installation
-            OR path LIKE '/Users/%%/.local/pipx/venvs/aider-chat/%'
+            OR path LIKE '/Users/%/.local/pipx/venvs/aider-chat/%'
     ),
     process_aider AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/anythingllm_local_server_detection.yml
+++ b/sample_osquery_checks/macOS/anythingllm_local_server_detection.yml
@@ -25,8 +25,8 @@ query: |
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
         WHERE path LIKE '/Applications/AnythingLLM.app'
-            OR path LIKE '/Users/%%/Library/Application Support/anythingllm-desktop/%'
-            OR path LIKE '/Users/%%/Library/Application Support/AnythingLLM/%'
+            OR path LIKE '/Users/%/Library/Application Support/anythingllm-desktop/%'
+            OR path LIKE '/Users/%/Library/Application Support/AnythingLLM/%'
     ),
     process_anyllm AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/chatgpt_desktop_detection.yml
+++ b/sample_osquery_checks/macOS/chatgpt_desktop_detection.yml
@@ -28,8 +28,8 @@ query: |
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
         WHERE path LIKE '/Applications/ChatGPT.app'
-            OR path LIKE '/Users/%%/Library/Application Support/ChatGPT/app-settings.json'
-            OR path LIKE '/Users/%%/Library/Application Support/ChatGPT/%'
+            OR path LIKE '/Users/%/Library/Application Support/ChatGPT/app-settings.json'
+            OR path LIKE '/Users/%/Library/Application Support/ChatGPT/%'
     ),
     process_chatgpt AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/claude_ai_assistant_detection.yml
+++ b/sample_osquery_checks/macOS/claude_ai_assistant_detection.yml
@@ -29,15 +29,15 @@ query: |
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
         WHERE path LIKE '/Applications/Claude.app'
-            OR path LIKE '/Users/%%/.claude/settings.json'
-            OR path LIKE '/Users/%%/.claude/CLAUDE.md'
-            OR path LIKE '/Users/%%/.local/bin/claude'
-            OR path LIKE '/Users/%%/.volta/bin/claude'
+            OR path LIKE '/Users/%/.claude/settings.json'
+            OR path LIKE '/Users/%/.claude/CLAUDE.md'
+            OR path LIKE '/Users/%/.local/bin/claude'
+            OR path LIKE '/Users/%/.volta/bin/claude'
             OR path LIKE '/usr/local/bin/claude'
             OR path LIKE '/opt/homebrew/bin/claude'
-            OR path LIKE '/Users/%%/node_modules/@anthropic-ai/claude-code/package.json'
+            OR path LIKE '/Users/%/node_modules/@anthropic-ai/claude-code/package.json'
             -- MCP configuration (Claude Desktop)
-            OR path LIKE '/Users/%%/Library/Application Support/Claude/claude_desktop_config.json'
+            OR path LIKE '/Users/%/Library/Application Support/Claude/claude_desktop_config.json'
     ),
     process_claude AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/cline_roo_ai_agent_detection.yml
+++ b/sample_osquery_checks/macOS/cline_roo_ai_agent_detection.yml
@@ -28,14 +28,14 @@ query: |
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
         -- VS Code extension directories (Cline and Roo-Cline)
-        WHERE path LIKE '/Users/%%/.vscode/extensions/saoudrizwan.claude-dev-%'
-            OR path LIKE '/Users/%%/.vscode/extensions/rooveterinaryinc.roo-cline-%'
+        WHERE path LIKE '/Users/%/.vscode/extensions/saoudrizwan.claude-dev-%'
+            OR path LIKE '/Users/%/.vscode/extensions/rooveterinaryinc.roo-cline-%'
             -- Cursor extension directories
-            OR path LIKE '/Users/%%/.cursor/extensions/saoudrizwan.claude-dev-%'
-            OR path LIKE '/Users/%%/.cursor/extensions/rooveterinaryinc.roo-cline-%'
+            OR path LIKE '/Users/%/.cursor/extensions/saoudrizwan.claude-dev-%'
+            OR path LIKE '/Users/%/.cursor/extensions/rooveterinaryinc.roo-cline-%'
             -- VS Code global storage confirms active usage (requires Full Disk Access)
-            OR path LIKE '/Users/%%/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/%'
-            OR path LIKE '/Users/%%/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/%'
+            OR path LIKE '/Users/%/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/%'
+            OR path LIKE '/Users/%/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/%'
     ),
     process_cline AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/continue_dev_ai_coding_assistant_detection.yml
+++ b/sample_osquery_checks/macOS/continue_dev_ai_coding_assistant_detection.yml
@@ -24,11 +24,11 @@ query: |
     WITH file_continue AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '/Users/%%/.continue/config.yaml'
-            OR path LIKE '/Users/%%/.continue/config.json'
-            OR path LIKE '/Users/%%/.continue/config.ts'
+        WHERE path LIKE '/Users/%/.continue/config.yaml'
+            OR path LIKE '/Users/%/.continue/config.json'
+            OR path LIKE '/Users/%/.continue/config.ts'
             -- VS Code extension directory
-            OR path LIKE '/Users/%%/.vscode/extensions/continue.continue-%'
+            OR path LIKE '/Users/%/.vscode/extensions/continue.continue-%'
     ),
     process_continue AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/cursor_ai_editor_detection.yml
+++ b/sample_osquery_checks/macOS/cursor_ai_editor_detection.yml
@@ -27,9 +27,9 @@ query: |
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
         WHERE path LIKE '/Applications/Cursor.app'
-            OR path LIKE '/Users/%%/.cursor/mcp.json'
-            OR path LIKE '/Users/%%/.cursor/extensions/%'
-            OR path LIKE '/Users/%%/Library/Application Support/Cursor/User/settings.json'
+            OR path LIKE '/Users/%/.cursor/mcp.json'
+            OR path LIKE '/Users/%/.cursor/extensions/%'
+            OR path LIKE '/Users/%/Library/Application Support/Cursor/User/settings.json'
     ),
     process_cursor AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/gemini_cli_detection.yml
+++ b/sample_osquery_checks/macOS/gemini_cli_detection.yml
@@ -23,12 +23,12 @@ query: |
     WITH file_gemini AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '/Users/%%/.gemini/settings.json'
-            OR path LIKE '/Users/%%/.volta/bin/gemini'
-            OR path LIKE '/Users/%%/.local/bin/gemini'
+        WHERE path LIKE '/Users/%/.gemini/settings.json'
+            OR path LIKE '/Users/%/.volta/bin/gemini'
+            OR path LIKE '/Users/%/.local/bin/gemini'
             OR path LIKE '/usr/local/bin/gemini'
             OR path LIKE '/opt/homebrew/bin/gemini'
-            OR path LIKE '/Users/%%/node_modules/@google/gemini-cli/package.json'
+            OR path LIKE '/Users/%/node_modules/@google/gemini-cli/package.json'
     ),
     process_gemini AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/github_copilot_detection.yml
+++ b/sample_osquery_checks/macOS/github_copilot_detection.yml
@@ -20,11 +20,11 @@ query: |
     WITH file_copilot AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '/Users/%%/.vscode/extensions/github.copilot-%'
-            OR path LIKE '/Users/%%/.vscode/extensions/github.copilot-chat-%'
-            OR path LIKE '/Users/%%/.config/github-copilot/hosts.json'
-            OR path LIKE '/Users/%%/.config/github-copilot/apps.json'
-            OR path LIKE '/Users/%%/node_modules/@github/copilot-language-server/package.json'
+        WHERE path LIKE '/Users/%/.vscode/extensions/github.copilot-%'
+            OR path LIKE '/Users/%/.vscode/extensions/github.copilot-chat-%'
+            OR path LIKE '/Users/%/.config/github-copilot/hosts.json'
+            OR path LIKE '/Users/%/.config/github-copilot/apps.json'
+            OR path LIKE '/Users/%/node_modules/@github/copilot-language-server/package.json'
     ),
     process_copilot AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/goose_ai_agent_detection.yml
+++ b/sample_osquery_checks/macOS/goose_ai_agent_detection.yml
@@ -25,12 +25,12 @@ query: |
     WITH file_goose AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '/Users/%%/.local/bin/goose'
+        WHERE path LIKE '/Users/%/.local/bin/goose'
             OR path LIKE '/opt/homebrew/bin/goose'
             OR path LIKE '/usr/local/bin/goose'
-            OR path LIKE '/Users/%%/.config/goose/profiles.yaml'
-            OR path LIKE '/Users/%%/.config/goose/config.yaml'
-            OR path LIKE '/Users/%%/.local/share/goose/sessions/%'
+            OR path LIKE '/Users/%/.config/goose/profiles.yaml'
+            OR path LIKE '/Users/%/.config/goose/config.yaml'
+            OR path LIKE '/Users/%/.local/share/goose/sessions/%'
     ),
     process_goose AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/gpt4all_local_llm_detection.yml
+++ b/sample_osquery_checks/macOS/gpt4all_local_llm_detection.yml
@@ -25,8 +25,8 @@ query: |
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
         WHERE path LIKE '/Applications/GPT4All.app'
-            OR path LIKE '/Users/%%/Library/Application Support/nomic.ai/GPT4All/%'
-            OR path LIKE '/Users/%%/Library/Application Support/GPT4All/%'
+            OR path LIKE '/Users/%/Library/Application Support/nomic.ai/GPT4All/%'
+            OR path LIKE '/Users/%/Library/Application Support/GPT4All/%'
     ),
     process_gpt4all AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/jan_ai_local_llm_detection.yml
+++ b/sample_osquery_checks/macOS/jan_ai_local_llm_detection.yml
@@ -24,9 +24,9 @@ query: |
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
         WHERE path LIKE '/Applications/Jan.app'
-            OR path LIKE '/Users/%%/.jan/models/%'
-            OR path LIKE '/Users/%%/.jan/settings.json'
-            OR path LIKE '/Users/%%/.jan/extensions/%'
+            OR path LIKE '/Users/%/.jan/models/%'
+            OR path LIKE '/Users/%/.jan/settings.json'
+            OR path LIKE '/Users/%/.jan/extensions/%'
     ),
     process_jan AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/kimi_code_ai_agent_detection.yml
+++ b/sample_osquery_checks/macOS/kimi_code_ai_agent_detection.yml
@@ -22,13 +22,13 @@ query: |
     WITH file_kimi AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '/Users/%%/.kimi-code/config.toml'
-            OR path LIKE '/Users/%%/.kimi-code/tui.toml'
-            OR path LIKE '/Users/%%/.kimi-code/mcp.json'
-            OR path LIKE '/Users/%%/.kimi-code/bin/kimi'
+        WHERE path LIKE '/Users/%/.kimi-code/config.toml'
+            OR path LIKE '/Users/%/.kimi-code/tui.toml'
+            OR path LIKE '/Users/%/.kimi-code/mcp.json'
+            OR path LIKE '/Users/%/.kimi-code/bin/kimi'
             OR path LIKE '/opt/homebrew/bin/kimi'
             OR path LIKE '/usr/local/bin/kimi'
-            OR path LIKE '/Users/%%/node_modules/@moonshot-ai/kimi-code/package.json'
+            OR path LIKE '/Users/%/node_modules/@moonshot-ai/kimi-code/package.json'
     ),
     process_kimi AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/kiro_amazon_q_detection.yml
+++ b/sample_osquery_checks/macOS/kiro_amazon_q_detection.yml
@@ -25,16 +25,16 @@ query: |
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
         WHERE path LIKE '/Applications/Kiro.app'
-            OR path LIKE '/Users/%%/.kiro/settings/cli.json'
-            OR path LIKE '/Users/%%/.kiro/settings/mcp.json'
-            OR path LIKE '/Users/%%/.local/bin/kiro-cli'
-            OR path LIKE '/Users/%%/.local/bin/kiro'
+            OR path LIKE '/Users/%/.kiro/settings/cli.json'
+            OR path LIKE '/Users/%/.kiro/settings/mcp.json'
+            OR path LIKE '/Users/%/.local/bin/kiro-cli'
+            OR path LIKE '/Users/%/.local/bin/kiro'
             -- Legacy Amazon Q Developer paths (pre-migration)
-            OR path LIKE '/Users/%%/.amazonq/scopes/scope.json'
+            OR path LIKE '/Users/%/.amazonq/scopes/scope.json'
             -- AWS Toolkit VS Code extension (ships Kiro/Q integration)
-            OR path LIKE '/Users/%%/.vscode/extensions/amazonwebservices.aws-toolkit-vscode-%'
+            OR path LIKE '/Users/%/.vscode/extensions/amazonwebservices.aws-toolkit-vscode-%'
             -- Legacy Amazon Q CLI binary (named q)
-            OR path LIKE '/Users/%%/.local/bin/q'
+            OR path LIKE '/Users/%/.local/bin/q'
     ),
     process_kiro AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/llamacpp_inference_server_detection.yml
+++ b/sample_osquery_checks/macOS/llamacpp_inference_server_detection.yml
@@ -28,7 +28,7 @@ query: |
             OR path LIKE '/opt/homebrew/bin/llama-run'
             OR path LIKE '/usr/local/bin/llama-server'
             OR path LIKE '/usr/local/bin/llama-cli'
-            OR path LIKE '/Users/%%/.local/bin/llama-server'
+            OR path LIKE '/Users/%/.local/bin/llama-server'
     ),
     process_llamacpp AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/lm_studio_local_llm_detection.yml
+++ b/sample_osquery_checks/macOS/lm_studio_local_llm_detection.yml
@@ -24,9 +24,9 @@ query: |
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
         WHERE path LIKE '/Applications/LM Studio.app'
-            OR path LIKE '/Users/%%/.lmstudio/models/%'
-            OR path LIKE '/Users/%%/.cache/lm-studio/%'
-            OR path LIKE '/Users/%%/.lmstudio/config.json'
+            OR path LIKE '/Users/%/.lmstudio/models/%'
+            OR path LIKE '/Users/%/.cache/lm-studio/%'
+            OR path LIKE '/Users/%/.lmstudio/config.json'
     ),
     process_lmstudio AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/ollama_local_llm_server_detection.yml
+++ b/sample_osquery_checks/macOS/ollama_local_llm_server_detection.yml
@@ -30,8 +30,8 @@ query: |
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
         WHERE path LIKE '/Applications/Ollama.app'
-            OR path LIKE '/Users/%%/.ollama/models/%'
-            OR path LIKE '/Users/%%/.ollama/config'
+            OR path LIKE '/Users/%/.ollama/models/%'
+            OR path LIKE '/Users/%/.ollama/config'
             OR path LIKE '/usr/local/bin/ollama'
             OR path LIKE '/opt/homebrew/bin/ollama'
     ),

--- a/sample_osquery_checks/macOS/openai_codex_cli_detection.yml
+++ b/sample_osquery_checks/macOS/openai_codex_cli_detection.yml
@@ -20,12 +20,12 @@ query: |
     WITH file_codex AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '/Users/%%/.codex/config.json'
-            OR path LIKE '/Users/%%/.volta/bin/codex'
-            OR path LIKE '/Users/%%/.local/bin/codex'
+        WHERE path LIKE '/Users/%/.codex/config.json'
+            OR path LIKE '/Users/%/.volta/bin/codex'
+            OR path LIKE '/Users/%/.local/bin/codex'
             OR path LIKE '/usr/local/bin/codex'
             OR path LIKE '/opt/homebrew/bin/codex'
-            OR path LIKE '/Users/%%/node_modules/@openai/codex/package.json'
+            OR path LIKE '/Users/%/node_modules/@openai/codex/package.json'
     ),
     process_codex AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/openclaw_personal_ai_assistant_detection.yml
+++ b/sample_osquery_checks/macOS/openclaw_personal_ai_assistant_detection.yml
@@ -16,10 +16,10 @@ query: |
     file_claw AS (
         SELECT COALESCE(COUNT(*), 0) as total
         FROM file 
-        WHERE path LIKE '/Users/%%/.openclaw/openclaw.json' 
-            -- OR path LIKE '/%%/.openclaw/%'
-            OR path LIKE '/Users/%%/.volta/bin/openclaw'
-            OR path LIKE '/Users/%%/.nvm/current/bin/openclaw'
+        WHERE path LIKE '/Users/%/.openclaw/openclaw.json' 
+            -- OR path LIKE '/%/.openclaw/%'
+            OR path LIKE '/Users/%/.volta/bin/openclaw'
+            OR path LIKE '/Users/%/.nvm/current/bin/openclaw'
             OR path LIKE '/usr/bin/openclaw'
             OR path LIKE '/usr/local/bin/openclaw'
             OR path LIKE '/opt/homebrew/bin/openclaw'

--- a/sample_osquery_checks/macOS/opencode_ai_agent_detection.yml
+++ b/sample_osquery_checks/macOS/opencode_ai_agent_detection.yml
@@ -22,12 +22,12 @@ query: |
     WITH file_opencode AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '/Users/%%/.local/bin/opencode'
+        WHERE path LIKE '/Users/%/.local/bin/opencode'
             OR path LIKE '/opt/homebrew/bin/opencode'
             OR path LIKE '/usr/local/bin/opencode'
-            OR path LIKE '/Users/%%/.config/opencode/config.json'
-            OR path LIKE '/Users/%%/.config/opencode/config.jsonc'
-            OR path LIKE '/Users/%%/node_modules/opencode-ai/package.json'
+            OR path LIKE '/Users/%/.config/opencode/config.json'
+            OR path LIKE '/Users/%/.config/opencode/config.jsonc'
+            OR path LIKE '/Users/%/node_modules/opencode-ai/package.json'
     ),
     process_opencode AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/sourcegraph_cody_detection.yml
+++ b/sample_osquery_checks/macOS/sourcegraph_cody_detection.yml
@@ -25,10 +25,10 @@ query: |
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
         -- VS Code and Cursor extension directories
-        WHERE path LIKE '/Users/%%/.vscode/extensions/sourcegraph.cody-ai-%'
-            OR path LIKE '/Users/%%/.cursor/extensions/sourcegraph.cody-ai-%'
+        WHERE path LIKE '/Users/%/.vscode/extensions/sourcegraph.cody-ai-%'
+            OR path LIKE '/Users/%/.cursor/extensions/sourcegraph.cody-ai-%'
             -- VS Code global storage confirms active usage (requires Full Disk Access)
-            OR path LIKE '/Users/%%/Library/Application Support/Code/User/globalStorage/sourcegraph.cody-ai/%'
+            OR path LIKE '/Users/%/Library/Application Support/Code/User/globalStorage/sourcegraph.cody-ai/%'
     ),
     process_cody AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/supermaven_ai_completion_detection.yml
+++ b/sample_osquery_checks/macOS/supermaven_ai_completion_detection.yml
@@ -24,11 +24,11 @@ query: |
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
         -- VS Code and Cursor extension directories
-        WHERE path LIKE '/Users/%%/.vscode/extensions/supermaven.supermaven-%'
-            OR path LIKE '/Users/%%/.cursor/extensions/supermaven.supermaven-%'
+        WHERE path LIKE '/Users/%/.vscode/extensions/supermaven.supermaven-%'
+            OR path LIKE '/Users/%/.cursor/extensions/supermaven.supermaven-%'
             -- VS Code global storage and app support (requires Full Disk Access)
-            OR path LIKE '/Users/%%/Library/Application Support/Code/User/globalStorage/supermaven.supermaven/%'
-            OR path LIKE '/Users/%%/Library/Application Support/Supermaven/%'
+            OR path LIKE '/Users/%/Library/Application Support/Code/User/globalStorage/supermaven.supermaven/%'
+            OR path LIKE '/Users/%/Library/Application Support/Supermaven/%'
     ),
     process_supermaven AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/tabnine_ai_coding_assistant_detection.yml
+++ b/sample_osquery_checks/macOS/tabnine_ai_coding_assistant_detection.yml
@@ -24,12 +24,12 @@ query: |
     WITH file_tabnine AS (
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
-        WHERE path LIKE '/Users/%%/.tabninecache/%'
-            OR path LIKE '/Users/%%/.tabnine/%'
+        WHERE path LIKE '/Users/%/.tabninecache/%'
+            OR path LIKE '/Users/%/.tabnine/%'
             -- VS Code extension
-            OR path LIKE '/Users/%%/.vscode/extensions/tabnine.tabnine-vscode-%'
+            OR path LIKE '/Users/%/.vscode/extensions/tabnine.tabnine-vscode-%'
             -- JetBrains plugin
-            OR path LIKE '/Users/%%/Library/Application Support/JetBrains/%%/plugins/tabnine-jetbrains/%'
+            OR path LIKE '/Users/%/Library/Application Support/JetBrains/%/plugins/tabnine-jetbrains/%'
     ),
     process_tabnine AS (
         SELECT COALESCE(COUNT(*), 0) AS total

--- a/sample_osquery_checks/macOS/windsurf_codeium_detection.yml
+++ b/sample_osquery_checks/macOS/windsurf_codeium_detection.yml
@@ -29,12 +29,12 @@ query: |
         SELECT COALESCE(COUNT(*), 0) AS total
         FROM file
         WHERE path LIKE '/Applications/Windsurf.app'
-            OR path LIKE '/Users/%%/.codeium/config.json'
-            OR path LIKE '/Users/%%/.codeium/settings/%'
-            OR path LIKE '/Users/%%/.windsurf/%'
-            OR path LIKE '/Users/%%/Library/Application Support/Windsurf/User/settings.json'
+            OR path LIKE '/Users/%/.codeium/config.json'
+            OR path LIKE '/Users/%/.codeium/settings/%'
+            OR path LIKE '/Users/%/.windsurf/%'
+            OR path LIKE '/Users/%/Library/Application Support/Windsurf/User/settings.json'
             -- MCP configuration
-            OR path LIKE '/Users/%%/.codeium/windsurf/mcp_config.json'
+            OR path LIKE '/Users/%/.codeium/windsurf/mcp_config.json'
     ),
     process_windsurf AS (
         SELECT COALESCE(COUNT(*), 0) AS total


### PR DESCRIPTION
## Summary
- osquery's `file` table only resolves the `%%` recursive glob when it is the trailing element of a path (confirmed against [1Password's article on osquery's file table](https://1password.com/blog/the-file-table-osquerys-secret-weapon)).
- Every macOS, Windows, and Cross sample check used `%%` mid-path (e.g. `/Users/%%/.claude/settings.json`), which never matches and silently returns zero rows.
- This meant the file-presence signal in all 49 affected checks was dead — each check has been relying solely on its other signals (processes, packages, launchd/startup items) without anyone noticing.
- Replaced mid-path `%%` with a single `%` (which matches as expected within `LIKE`) across all 50 affected files (201 occurrences total). No other logic changed.

## Test plan
- [x] Confirmed via full-repo scan that every `%%` occurrence was mid-path (none were legitimate trailing usage)
- [x] Confirmed 0 remaining `%%` occurrences after the fix
- [x] Spot-checked multi-occurrence lines (e.g. JetBrains path with two `%%`) fixed correctly
- [ ] No functional/runtime testing applicable — these are sample checks, not deployed detections